### PR TITLE
Add builders to DTOs/entities and update expense endpoint

### DIFF
--- a/src/integrationTest/java/com/novelosoftware/expenses/controllers/ExpenseControllerIT.java
+++ b/src/integrationTest/java/com/novelosoftware/expenses/controllers/ExpenseControllerIT.java
@@ -6,15 +6,20 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 class ExpenseControllerIT extends BaseIT {
 
-    private long accountId;
+    private static final String USER = "user-expense-it";
+
+    private long firstAccountId;
+    private long secondAccountId;
 
     @BeforeEach
     void setUp() throws Exception {
-        accountId = createAccount("Test Account", "user-expense-it");
+        firstAccountId = createAccount("Test Account", USER);
+        secondAccountId = createAccount("Second account", USER);
     }
 
     // -------------------------------------------------------------------------
@@ -29,11 +34,11 @@ class ExpenseControllerIT extends BaseIT {
                     { "value": { "expenseDate": "2026-05-27", "accountId": %d,
                       "amount": 42.50, "description": "Test tacos",
                       "subCategory": "RESTAURANT", "createdBy": "user-expense-it" } }
-                """.formatted(accountId)))
+                """.formatted(firstAccountId)))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.value.expenseId").isNumber())
             .andExpect(jsonPath("$.value.expenseDate").value("2026-05-27"))
-            .andExpect(jsonPath("$.value.accountId").value(accountId))
+            .andExpect(jsonPath("$.value.accountId").value(firstAccountId))
             .andExpect(jsonPath("$.value.amount").value(42.50))
             .andExpect(jsonPath("$.value.description").value("Test tacos"))
             .andExpect(jsonPath("$.value.subCategory").value("RESTAURANT"))
@@ -61,7 +66,7 @@ class ExpenseControllerIT extends BaseIT {
                     { "value": { "expenseDate": "2026-05-27", "accountId": %d,
                       "amount": 42.50, "description": "Test tacos",
                       "subCategory": "RESTAURANT", "createdBy": "user-B" } }
-                """.formatted(accountId)))
+                """.formatted(firstAccountId)))
             .andExpect(status().isForbidden())
             .andExpect(jsonPath("$.code").value("FORBIDDEN"));
     }
@@ -74,7 +79,7 @@ class ExpenseControllerIT extends BaseIT {
                     { "value": { "expenseDate": null, "accountId": %d,
                       "amount": 42.50, "description": "Test tacos",
                       "subCategory": "RESTAURANT", "createdBy": "user-expense-it" } }
-                """.formatted(accountId)))
+                """.formatted(firstAccountId)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
             .andExpect(jsonPath("$.message").value("expenseDate cannot be null"));
@@ -101,7 +106,7 @@ class ExpenseControllerIT extends BaseIT {
                     { "value": { "expenseDate": "2026-05-27", "accountId": %d,
                       "amount": null, "description": "Test tacos",
                       "subCategory": "RESTAURANT", "createdBy": "user-expense-it" } }
-                """.formatted(accountId)))
+                """.formatted(firstAccountId)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.code").value("BAD_REQUEST"));
     }
@@ -114,7 +119,7 @@ class ExpenseControllerIT extends BaseIT {
                     { "value": { "expenseDate": "2026-05-27", "accountId": %d,
                       "amount": 42.50, "description": "",
                       "subCategory": "RESTAURANT", "createdBy": "user-expense-it" } }
-                """.formatted(accountId)))
+                """.formatted(firstAccountId)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.code").value("BAD_REQUEST"));
     }
@@ -127,7 +132,7 @@ class ExpenseControllerIT extends BaseIT {
                     { "value": { "expenseDate": "2026-05-27", "accountId": %d,
                       "amount": 42.50, "description": "Test tacos",
                       "subCategory": null, "createdBy": "user-expense-it" } }
-                """.formatted(accountId)))
+                """.formatted(firstAccountId)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.code").value("BAD_REQUEST"));
     }
@@ -140,7 +145,7 @@ class ExpenseControllerIT extends BaseIT {
                     { "value": { "expenseDate": "2026-05-27", "accountId": %d,
                       "amount": 42.50, "description": "Test tacos",
                       "subCategory": "RESTAURANT", "createdBy": "" } }
-                """.formatted(accountId)))
+                """.formatted(firstAccountId)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.code").value("BAD_REQUEST"));
     }
@@ -153,7 +158,7 @@ class ExpenseControllerIT extends BaseIT {
                     { "value": { "expenseDate": "2026-05-27", "accountId": %d,
                       "amount": 42.50, "description": "Test tacos",
                       "subCategory": "INVALID_ENUM", "createdBy": "user-expense-it" } }
-                """.formatted(accountId)))
+                """.formatted(firstAccountId)))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
             .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("INVALID_ENUM")));
@@ -181,8 +186,122 @@ class ExpenseControllerIT extends BaseIT {
                     { "value": { "expenseDate": "2026-05-27", "accountId": %d,
                       "amount": 15.00, "description": "Lunch",
                       "subCategory": "GROCERIES", "createdBy": "user-expense-it" } }
-                """.formatted(accountId)))
+                """.formatted(firstAccountId)))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.value.subCategory").value("GROCERIES"));
+    }
+
+    @Test
+    void update_happyPath() throws Exception {
+        Long expenseId = createExpense(firstAccountId, USER);
+        mockMvc.perform(put("/expenses/" + expenseId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                        "value": {
+                            "expenseId": %d,
+                            "expenseDate": "2026-01-15",
+                            "accountId": %d,
+                            "amount": 42.50,
+                            "description": "Test expense",
+                            "subCategory": "RESTAURANT",
+                            "createdBy": "%s"
+                        }
+                    }
+                """.formatted(expenseId, secondAccountId, USER)))
+            .andExpect(status().is2xxSuccessful())
+            .andExpect(jsonPath("$.value.accountId").value(secondAccountId));
+    }
+
+    @Test
+    void update_unauthorizedOwnerChange() throws Exception {
+        Long expenseId = createExpense(firstAccountId, USER);
+        mockMvc.perform(put("/expenses/" + expenseId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                        "value": {
+                            "expenseId": %d,
+                            "expenseDate": "2026-01-15",
+                            "accountId": %d,
+                            "amount": 42.50,
+                            "description": "Test expense",
+                            "subCategory": "RESTAURANT",
+                            "createdBy": "%s"
+                        }
+                    }
+                """.formatted(expenseId, firstAccountId, "another-user")))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+            .andExpect(jsonPath("$.message").value("User does not own the given account"));
+    }
+
+    @Test
+    void update_unauthorizedAccountOnwerChange() throws Exception {
+        Long expenseId = createExpense(firstAccountId, USER);
+        Long thirdAccount = createAccount("third-person-account", "another-user-id");
+        mockMvc.perform(put("/expenses/" + expenseId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                        "value": {
+                            "expenseId": %d,
+                            "expenseDate": "2026-01-15",
+                            "accountId": %d,
+                            "amount": 42.50,
+                            "description": "Test expense",
+                            "subCategory": "RESTAURANT",
+                            "createdBy": "%s"
+                        }
+                    }
+                """.formatted(expenseId, thirdAccount, USER)))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+            .andExpect(jsonPath("$.message").value("User does not own the given account"));
+    }
+
+    @Test
+    void update_expenseDoesNotExists() throws Exception {
+        mockMvc.perform(put("/expenses/999999")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                        "value": {
+                            "expenseId": 999999,
+                            "expenseDate": "2026-01-15",
+                            "accountId": %d,
+                            "amount": 42.50,
+                            "description": "Test expense",
+                            "subCategory": "RESTAURANT",
+                            "createdBy": "%s"
+                        }
+                    }
+                """.formatted(secondAccountId, USER)))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("NOT_FOUND"))
+            .andExpect(jsonPath("$.message").value("Expense id 999999 not found"));
+    }
+
+    @Test
+    void update_accountNotFound() throws Exception {
+        long expenseId = createExpense(firstAccountId, USER);
+        mockMvc.perform(put("/expenses/" + expenseId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                        "value": {
+                            "expenseId": %d,
+                            "expenseDate": "2026-01-15",
+                            "accountId": %d,
+                            "amount": 42.50,
+                            "description": "Test expense",
+                            "subCategory": "RESTAURANT",
+                            "createdBy": "%s"
+                        }
+                    }
+                """.formatted(expenseId, 999999, USER)))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("NOT_FOUND"))
+            .andExpect(jsonPath("$.message").value("Account with ID 999999 not found."));
     }
 }

--- a/src/main/java/com/novelosoftware/expenses/controllers/AccountController.java
+++ b/src/main/java/com/novelosoftware/expenses/controllers/AccountController.java
@@ -42,11 +42,11 @@ public class AccountController {
      * @return paginated accounts owned by the user
      */
     @GetMapping("/user/{userId}")
-    public PageResponse<Account> getByUser(
+    public PageResponse<Account> findByUser(
             @PathVariable String userId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
-        return service.getByUser(userId, page, size);
+        return service.findByUser(userId, page, size);
     }
 
     /**

--- a/src/main/java/com/novelosoftware/expenses/controllers/ExpenseController.java
+++ b/src/main/java/com/novelosoftware/expenses/controllers/ExpenseController.java
@@ -1,7 +1,9 @@
 package com.novelosoftware.expenses.controllers;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -9,7 +11,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.novelosoftware.expenses.dto.CreateExpenseRequest;
 import com.novelosoftware.expenses.dto.CreateExpenseResponse;
+import com.novelosoftware.expenses.dto.Expense;
+import com.novelosoftware.expenses.dto.UpdateExpenseRequest;
+import com.novelosoftware.expenses.dto.UpdateExpenseResponse;
 import com.novelosoftware.expenses.services.ExpenseService;
+
+import jakarta.websocket.server.PathParam;
 
 /**
  * ExpenseController contains APIs for Expense entities.
@@ -33,5 +40,10 @@ public class ExpenseController {
     @ResponseStatus(HttpStatus.CREATED)
     public CreateExpenseResponse create(@RequestBody CreateExpenseRequest request) {
         return expenseService.create(request);
+    }
+
+    @PutMapping("/{id}")
+    public UpdateExpenseResponse update(@PathVariable Long id, @RequestBody UpdateExpenseRequest request) {
+        return expenseService.update(id, request);
     }
 }

--- a/src/main/java/com/novelosoftware/expenses/dto/Account.java
+++ b/src/main/java/com/novelosoftware/expenses/dto/Account.java
@@ -21,4 +21,43 @@ public record Account(
     BigDecimal currentAmount,
     /** ID of the user who owns this account. */
     String createdBy
-) {}
+) {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Builder toBuilder() {
+        return new Builder()
+            .accountId(accountId)
+            .name(name)
+            .accountType(accountType)
+            .currency(currency)
+            .initialAmount(initialAmount)
+            .currentAmount(currentAmount)
+            .createdBy(createdBy);
+    }
+
+    public static final class Builder {
+        private Long accountId;
+        private String name;
+        private AccountType accountType;
+        private String currency;
+        private BigDecimal initialAmount;
+        private BigDecimal currentAmount;
+        private String createdBy;
+
+        private Builder() {}
+
+        public Builder accountId(Long accountId) { this.accountId = accountId; return this; }
+        public Builder name(String name) { this.name = name; return this; }
+        public Builder accountType(AccountType accountType) { this.accountType = accountType; return this; }
+        public Builder currency(String currency) { this.currency = currency; return this; }
+        public Builder initialAmount(BigDecimal initialAmount) { this.initialAmount = initialAmount; return this; }
+        public Builder currentAmount(BigDecimal currentAmount) { this.currentAmount = currentAmount; return this; }
+        public Builder createdBy(String createdBy) { this.createdBy = createdBy; return this; }
+
+        public Account build() {
+            return new Account(accountId, name, accountType, currency, initialAmount, currentAmount, createdBy);
+        }
+    }
+}

--- a/src/main/java/com/novelosoftware/expenses/dto/CreateAccountRequest.java
+++ b/src/main/java/com/novelosoftware/expenses/dto/CreateAccountRequest.java
@@ -5,4 +5,24 @@ package com.novelosoftware.expenses.dto;
  */
 public record CreateAccountRequest(
     Account value
-) {}
+) {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Builder toBuilder() {
+        return new Builder().value(value);
+    }
+
+    public static final class Builder {
+        private Account value;
+
+        private Builder() {}
+
+        public Builder value(Account value) { this.value = value; return this; }
+
+        public CreateAccountRequest build() {
+            return new CreateAccountRequest(value);
+        }
+    }
+}

--- a/src/main/java/com/novelosoftware/expenses/dto/CreateAccountResponse.java
+++ b/src/main/java/com/novelosoftware/expenses/dto/CreateAccountResponse.java
@@ -7,4 +7,24 @@ package com.novelosoftware.expenses.dto;
 public record CreateAccountResponse(
     /** The newly created account. */
     Account value
-) {}
+) {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Builder toBuilder() {
+        return new Builder().value(value);
+    }
+
+    public static final class Builder {
+        private Account value;
+
+        private Builder() {}
+
+        public Builder value(Account value) { this.value = value; return this; }
+
+        public CreateAccountResponse build() {
+            return new CreateAccountResponse(value);
+        }
+    }
+}

--- a/src/main/java/com/novelosoftware/expenses/dto/CreateExpenseRequest.java
+++ b/src/main/java/com/novelosoftware/expenses/dto/CreateExpenseRequest.java
@@ -5,4 +5,24 @@ package com.novelosoftware.expenses.dto;
  */
 public record CreateExpenseRequest(
     Expense value
-) {}
+) {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Builder toBuilder() {
+        return new Builder().value(value);
+    }
+
+    public static final class Builder {
+        private Expense value;
+
+        private Builder() {}
+
+        public Builder value(Expense value) { this.value = value; return this; }
+
+        public CreateExpenseRequest build() {
+            return new CreateExpenseRequest(value);
+        }
+    }
+}

--- a/src/main/java/com/novelosoftware/expenses/dto/Expense.java
+++ b/src/main/java/com/novelosoftware/expenses/dto/Expense.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 /**
  * Expense exposes a single expense line
  */
-public record Expense (
+public record Expense(
     /** ID of the expense */
     Long expenseId,
     /** Date when the expense happened */
@@ -20,5 +20,44 @@ public record Expense (
     /** sub-category o the expense, category can be infered from here */
     SubCategory subCategory,
     /** onwer of expense */
-    String createdBy 
-){}
+    String createdBy
+) {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Builder toBuilder() {
+        return new Builder()
+            .expenseId(expenseId)
+            .expenseDate(expenseDate)
+            .accountId(accountId)
+            .amount(amount)
+            .description(description)
+            .subCategory(subCategory)
+            .createdBy(createdBy);
+    }
+
+    public static final class Builder {
+        private Long expenseId;
+        private LocalDate expenseDate;
+        private Long accountId;
+        private BigDecimal amount;
+        private String description;
+        private SubCategory subCategory;
+        private String createdBy;
+
+        private Builder() {}
+
+        public Builder expenseId(Long expenseId) { this.expenseId = expenseId; return this; }
+        public Builder expenseDate(LocalDate expenseDate) { this.expenseDate = expenseDate; return this; }
+        public Builder accountId(Long accountId) { this.accountId = accountId; return this; }
+        public Builder amount(BigDecimal amount) { this.amount = amount; return this; }
+        public Builder description(String description) { this.description = description; return this; }
+        public Builder subCategory(SubCategory subCategory) { this.subCategory = subCategory; return this; }
+        public Builder createdBy(String createdBy) { this.createdBy = createdBy; return this; }
+
+        public Expense build() {
+            return new Expense(expenseId, expenseDate, accountId, amount, description, subCategory, createdBy);
+        }
+    }
+}

--- a/src/main/java/com/novelosoftware/expenses/dto/PageResponse.java
+++ b/src/main/java/com/novelosoftware/expenses/dto/PageResponse.java
@@ -31,4 +31,37 @@ public record PageResponse<T>(
         int totalPages = size == 0 ? 0 : (int) Math.ceil((double) totalElements / size);
         return new PageResponse<>(content, page, size, totalElements, totalPages);
     }
+
+    public static <T> Builder<T> builder() {
+        return new Builder<>();
+    }
+
+    public Builder<T> toBuilder() {
+        return new Builder<T>()
+            .content(content)
+            .page(page)
+            .size(size)
+            .totalElements(totalElements)
+            .totalPages(totalPages);
+    }
+
+    public static final class Builder<T> {
+        private List<T> content;
+        private int page;
+        private int size;
+        private long totalElements;
+        private int totalPages;
+
+        private Builder() {}
+
+        public Builder<T> content(List<T> content) { this.content = content; return this; }
+        public Builder<T> page(int page) { this.page = page; return this; }
+        public Builder<T> size(int size) { this.size = size; return this; }
+        public Builder<T> totalElements(long totalElements) { this.totalElements = totalElements; return this; }
+        public Builder<T> totalPages(int totalPages) { this.totalPages = totalPages; return this; }
+
+        public PageResponse<T> build() {
+            return new PageResponse<>(content, page, size, totalElements, totalPages);
+        }
+    }
 }

--- a/src/main/java/com/novelosoftware/expenses/dto/UpdateAccountRequest.java
+++ b/src/main/java/com/novelosoftware/expenses/dto/UpdateAccountRequest.java
@@ -5,4 +5,24 @@ package com.novelosoftware.expenses.dto;
  */
 public record UpdateAccountRequest(
     Account value
-) {}
+) {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Builder toBuilder() {
+        return new Builder().value(value);
+    }
+
+    public static final class Builder {
+        private Account value;
+
+        private Builder() {}
+
+        public Builder value(Account value) { this.value = value; return this; }
+
+        public UpdateAccountRequest build() {
+            return new UpdateAccountRequest(value);
+        }
+    }
+}

--- a/src/main/java/com/novelosoftware/expenses/dto/UpdateAccountResponse.java
+++ b/src/main/java/com/novelosoftware/expenses/dto/UpdateAccountResponse.java
@@ -7,4 +7,24 @@ package com.novelosoftware.expenses.dto;
 public record UpdateAccountResponse(
     /** The updated account. */
     Account value
-) {}
+) {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Builder toBuilder() {
+        return new Builder().value(value);
+    }
+
+    public static final class Builder {
+        private Account value;
+
+        private Builder() {}
+
+        public Builder value(Account value) { this.value = value; return this; }
+
+        public UpdateAccountResponse build() {
+            return new UpdateAccountResponse(value);
+        }
+    }
+}

--- a/src/main/java/com/novelosoftware/expenses/dto/UpdateExpenseRequest.java
+++ b/src/main/java/com/novelosoftware/expenses/dto/UpdateExpenseRequest.java
@@ -1,10 +1,7 @@
 package com.novelosoftware.expenses.dto;
 
-/**
- * Create expense reponse wrapper with created expense.
- */
-public record CreateExpenseResponse(
-    /** The newly created expense */
+
+public record UpdateExpenseRequest(
     Expense value
 ) {
     public static Builder builder() {
@@ -22,8 +19,8 @@ public record CreateExpenseResponse(
 
         public Builder value(Expense value) { this.value = value; return this; }
 
-        public CreateExpenseResponse build() {
-            return new CreateExpenseResponse(value);
+        public UpdateExpenseRequest build() {
+            return new UpdateExpenseRequest(value);
         }
     }
 }

--- a/src/main/java/com/novelosoftware/expenses/dto/UpdateExpenseResponse.java
+++ b/src/main/java/com/novelosoftware/expenses/dto/UpdateExpenseResponse.java
@@ -1,10 +1,6 @@
 package com.novelosoftware.expenses.dto;
 
-/**
- * Create expense reponse wrapper with created expense.
- */
-public record CreateExpenseResponse(
-    /** The newly created expense */
+public record UpdateExpenseResponse(
     Expense value
 ) {
     public static Builder builder() {
@@ -22,8 +18,8 @@ public record CreateExpenseResponse(
 
         public Builder value(Expense value) { this.value = value; return this; }
 
-        public CreateExpenseResponse build() {
-            return new CreateExpenseResponse(value);
+        public UpdateExpenseResponse build() {
+            return new UpdateExpenseResponse(value);
         }
     }
 }

--- a/src/main/java/com/novelosoftware/expenses/entities/AccountEntity.java
+++ b/src/main/java/com/novelosoftware/expenses/entities/AccountEntity.java
@@ -28,4 +28,49 @@ public record AccountEntity(
     OffsetDateTime updatedAt,
     /** ID of the user who owns this account. */
     String createdBy
-) {}
+) {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Builder toBuilder() {
+        return new Builder()
+            .accountId(accountId)
+            .name(name)
+            .accountType(accountType)
+            .currency(currency)
+            .initialAmount(initialAmount)
+            .currentAmount(currentAmount)
+            .createdAt(createdAt)
+            .updatedAt(updatedAt)
+            .createdBy(createdBy);
+    }
+
+    public static final class Builder {
+        private Long accountId;
+        private String name;
+        private AccountType accountType;
+        private String currency;
+        private BigDecimal initialAmount;
+        private BigDecimal currentAmount;
+        private OffsetDateTime createdAt;
+        private OffsetDateTime updatedAt;
+        private String createdBy;
+
+        private Builder() {}
+
+        public Builder accountId(Long accountId) { this.accountId = accountId; return this; }
+        public Builder name(String name) { this.name = name; return this; }
+        public Builder accountType(AccountType accountType) { this.accountType = accountType; return this; }
+        public Builder currency(String currency) { this.currency = currency; return this; }
+        public Builder initialAmount(BigDecimal initialAmount) { this.initialAmount = initialAmount; return this; }
+        public Builder currentAmount(BigDecimal currentAmount) { this.currentAmount = currentAmount; return this; }
+        public Builder createdAt(OffsetDateTime createdAt) { this.createdAt = createdAt; return this; }
+        public Builder updatedAt(OffsetDateTime updatedAt) { this.updatedAt = updatedAt; return this; }
+        public Builder createdBy(String createdBy) { this.createdBy = createdBy; return this; }
+
+        public AccountEntity build() {
+            return new AccountEntity(accountId, name, accountType, currency, initialAmount, currentAmount, createdAt, updatedAt, createdBy);
+        }
+    }
+}

--- a/src/main/java/com/novelosoftware/expenses/entities/ExpenseEntity.java
+++ b/src/main/java/com/novelosoftware/expenses/entities/ExpenseEntity.java
@@ -24,4 +24,46 @@ public record ExpenseEntity(
     String subcategory,
     /** ID of the user who created this expense. */
     String createdBy
-) {}
+) {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Builder toBuilder() {
+        return new Builder()
+            .expenseId(expenseId)
+            .expenseDate(expenseDate)
+            .accountId(accountId)
+            .amount(amount)
+            .description(description)
+            .category(category)
+            .subcategory(subcategory)
+            .createdBy(createdBy);
+    }
+
+    public static final class Builder {
+        private Long expenseId;
+        private LocalDate expenseDate;
+        private Long accountId;
+        private BigDecimal amount;
+        private String description;
+        private String category;
+        private String subcategory;
+        private String createdBy;
+
+        private Builder() {}
+
+        public Builder expenseId(Long expenseId) { this.expenseId = expenseId; return this; }
+        public Builder expenseDate(LocalDate expenseDate) { this.expenseDate = expenseDate; return this; }
+        public Builder accountId(Long accountId) { this.accountId = accountId; return this; }
+        public Builder amount(BigDecimal amount) { this.amount = amount; return this; }
+        public Builder description(String description) { this.description = description; return this; }
+        public Builder category(String category) { this.category = category; return this; }
+        public Builder subcategory(String subcategory) { this.subcategory = subcategory; return this; }
+        public Builder createdBy(String createdBy) { this.createdBy = createdBy; return this; }
+
+        public ExpenseEntity build() {
+            return new ExpenseEntity(expenseId, expenseDate, accountId, amount, description, category, subcategory, createdBy);
+        }
+    }
+}

--- a/src/main/java/com/novelosoftware/expenses/exceptions/ExpenseServiceExceptions.java
+++ b/src/main/java/com/novelosoftware/expenses/exceptions/ExpenseServiceExceptions.java
@@ -1,5 +1,7 @@
 package com.novelosoftware.expenses.exceptions;
 
+import com.novelosoftware.expenses.dto.Expense;
+
 /**
  * Exception factory for Expenses service
  */
@@ -21,8 +23,17 @@ public final class ExpenseServiceExceptions {
      * @param message description of the exception
      * @return an ExpenseValidationException
      */
-    public static UnauthorizedAccountException createUnauthorizedAccountException(String message){
-        return new UnauthorizedAccountException(message);
+    public static UnauthorizedExpenseException createUnauthorizedExpenseException(String message){
+        return new UnauthorizedExpenseException(message);
+    }
+
+    /**
+     * Creates an ExpenseNotFoundException
+     * @param message description of the exception
+     * @return an ExpenseNotFoundException
+     */
+    public static ExpenseNotFoundException createExpenseNotFoundException(Long id) {
+        return new ExpenseNotFoundException("Expense id " + id + " not found");
     }
 
     /**
@@ -37,8 +48,14 @@ public final class ExpenseServiceExceptions {
     /**
      * Unauthorized access to accounts that don't belong to the user.
      */
-    public static final class UnauthorizedAccountException extends RuntimeException {
-        private UnauthorizedAccountException(String message) {
+    public static final class UnauthorizedExpenseException extends RuntimeException {
+        private UnauthorizedExpenseException(String message) {
+            super(message);
+        }
+    }
+
+    public static final class ExpenseNotFoundException extends RuntimeException {
+        private ExpenseNotFoundException(String message) {
             super(message);
         }
     }

--- a/src/main/java/com/novelosoftware/expenses/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/novelosoftware/expenses/exceptions/GlobalExceptionHandler.java
@@ -3,21 +3,23 @@ package com.novelosoftware.expenses.exceptions;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.novelosoftware.expenses.exceptions.AccountServiceExceptions.AccountNotFoundException;
 import com.novelosoftware.expenses.exceptions.AccountServiceExceptions.AccountValidationException;
-import com.novelosoftware.expenses.exceptions.ExpenseServiceExceptions.ExpenseValidationException;
-import com.novelosoftware.expenses.exceptions.ExpenseServiceExceptions.UnauthorizedAccountException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
+
+import static com.novelosoftware.expenses.exceptions.ExpenseServiceExceptions.*;
 
 /**
  * Global exception handler for all REST controllers.
@@ -114,10 +116,21 @@ public class GlobalExceptionHandler {
      * @param ex the exception carrying the invalid reason
      * @return 403 response with UNAUTHORIZED error code
      */
-    @ExceptionHandler(UnauthorizedAccountException.class)
-    public ResponseEntity<ErrorResponse> handleUnauthorizedAccountException(UnauthorizedAccountException ex) {
+    @ExceptionHandler(UnauthorizedExpenseException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthorizedAccountException(UnauthorizedExpenseException ex) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
             .body(new ErrorResponse("FORBIDDEN", ex.getMessage()));
+    }
+
+    /**
+     * Handles when requested expense does not exists.
+     * @param ex ExpenseNotFoundException  carrying the invalid reason
+     * @return 404 reponse with NOT_FOUND error code.
+     */
+    @ExceptionHandler(ExpenseNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleExpenseNotFoundException(ExpenseNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(new ErrorResponse("NOT_FOUND", ex.getMessage()));
     }
 
     /**

--- a/src/main/java/com/novelosoftware/expenses/repositories/ExpenseRepository.java
+++ b/src/main/java/com/novelosoftware/expenses/repositories/ExpenseRepository.java
@@ -16,16 +16,9 @@ import java.util.Optional;
 @Repository
 public class ExpenseRepository {
 
-    private final JdbcTemplate jdbc;
+    static final String GET_SQL = "SELECT * FROM expenses WHERE expense_id = ?";
 
-    /**
-     * @param jdbc the JdbcTemplate used to execute queries
-     */
-    public ExpenseRepository(JdbcTemplate jdbc) {
-        this.jdbc = jdbc;
-    }
-
-    private static final RowMapper<ExpenseEntity> mapper = (rs, row) -> new ExpenseEntity(
+    static final RowMapper<ExpenseEntity> MAPPER = (rs, row) -> new ExpenseEntity(
         rs.getLong("expense_id"),
         rs.getObject("expense_date", LocalDate.class),
         rs.getLong("account_id"),
@@ -35,6 +28,15 @@ public class ExpenseRepository {
         rs.getString("subcategory"),
         rs.getString("created_by")
     );
+
+    private final JdbcTemplate jdbc;
+
+    /**
+     * @param jdbc the JdbcTemplate used to execute queries
+     */
+    public ExpenseRepository(JdbcTemplate jdbc) {
+        this.jdbc = jdbc;
+    }
 
     // -------------------------------------------------------------------------
     // Write operations
@@ -52,7 +54,7 @@ public class ExpenseRepository {
             VALUES (?, ?, ?, ?, ?, ?, ?)
             RETURNING *
             """;
-        return jdbc.queryForObject(sql, mapper,
+        return jdbc.queryForObject(sql, MAPPER,
             entity.expenseDate(), entity.accountId(), entity.amount(),
             entity.description(), entity.category(), entity.subcategory(), entity.createdBy());
     }
@@ -72,7 +74,7 @@ public class ExpenseRepository {
             WHERE expense_id = ?
             RETURNING *
             """;
-        var results = jdbc.query(sql, mapper,
+        var results = jdbc.query(sql, MAPPER,
             entity.expenseDate(), entity.accountId(), entity.amount(),
             entity.description(), entity.category(), entity.subcategory(), id);
         return results.stream().findFirst();
@@ -110,7 +112,7 @@ public class ExpenseRepository {
             ORDER BY expense_date DESC
             LIMIT ? OFFSET ?
             """;
-        return jdbc.query(sql, mapper, userId, startDate, endDate, limit, offset);
+        return jdbc.query(sql, MAPPER, userId, startDate, endDate, limit, offset);
     }
 
     /**
@@ -149,7 +151,11 @@ public class ExpenseRepository {
             ORDER BY expense_date DESC
             LIMIT ? OFFSET ?
             """;
-        return jdbc.query(sql, mapper, userId, accountId, startDate, endDate, limit, offset);
+        return jdbc.query(sql, MAPPER, userId, accountId, startDate, endDate, limit, offset);
+    }
+
+    public Optional<ExpenseEntity> get(Long expenseId) {
+        return jdbc.query(GET_SQL, MAPPER, expenseId).stream().findFirst();
     }
 
     /**
@@ -190,7 +196,7 @@ public class ExpenseRepository {
             ORDER BY expense_date DESC
             LIMIT ? OFFSET ?
             """;
-        return jdbc.query(sql, mapper, userId, category, startDate, endDate, limit, offset);
+        return jdbc.query(sql, MAPPER, userId, category, startDate, endDate, limit, offset);
     }
 
     /**
@@ -229,7 +235,7 @@ public class ExpenseRepository {
             ORDER BY expense_date DESC
             LIMIT ? OFFSET ?
             """;
-        return jdbc.query(sql, mapper, userId, subcategory, startDate, endDate, limit, offset);
+        return jdbc.query(sql, MAPPER, userId, subcategory, startDate, endDate, limit, offset);
     }
 
     /**

--- a/src/main/java/com/novelosoftware/expenses/services/AccountService.java
+++ b/src/main/java/com/novelosoftware/expenses/services/AccountService.java
@@ -48,10 +48,10 @@ public class AccountService {
      * @param size   number of items per page
      * @return paginated response containing account DTOs and pagination metadata
      */
-    public PageResponse<Account> getByUser(String userId, int page, int size) {
+    public PageResponse<Account> findByUser(String userId, int page, int size) {
+        var total = repo.countByUser(userId);
         var content = repo.findByUser(userId, size, page * size)
             .stream().map(AccountMapper::toDto).toList();
-        var total = repo.countByUser(userId);
         return PageResponse.of(content, page, size, total);
     }
 

--- a/src/main/java/com/novelosoftware/expenses/services/ExpenseService.java
+++ b/src/main/java/com/novelosoftware/expenses/services/ExpenseService.java
@@ -6,6 +6,8 @@ import com.novelosoftware.expenses.dto.Account;
 import com.novelosoftware.expenses.dto.CreateExpenseRequest;
 import com.novelosoftware.expenses.dto.CreateExpenseResponse;
 import com.novelosoftware.expenses.dto.Expense;
+import com.novelosoftware.expenses.dto.UpdateExpenseRequest;
+import com.novelosoftware.expenses.dto.UpdateExpenseResponse;
 import com.novelosoftware.expenses.entities.ExpenseEntity;
 import com.novelosoftware.expenses.mappers.ExpenseMapper;
 import com.novelosoftware.expenses.repositories.ExpenseRepository;
@@ -42,7 +44,31 @@ public class ExpenseService {
         ExpenseEntity expenseEntity = ExpenseMapper.toEntity(expense);
         ExpenseEntity createdEntity = repo.create(expenseEntity);
         return new CreateExpenseResponse(ExpenseMapper.toDto(createdEntity));
-    }  
+    }
+
+    public UpdateExpenseResponse update(Long id, UpdateExpenseRequest request) {
+        if (request == null || request.value() == null)  {
+            throw createValidationException("Expense payload not provided");
+        }
+
+        if (id == null) {
+            throw createValidationException("ID not provided");
+        }
+
+        Expense expense = request.value();
+        expenseWriteValidations(expense);
+
+        // Payload is validated now we can bring previous version and make sure this is the owner.
+        ExpenseEntity oldExpense = repo.get(id).orElseThrow(() -> createExpenseNotFoundException(id));
+
+        if (!expense.createdBy().equals(oldExpense.createdBy())) {
+            throw createUnauthorizedExpenseException("Expense not owned by viewer");
+        }
+
+        ExpenseEntity newExpense = ExpenseMapper.toEntity(expense);
+        ExpenseEntity updatedEntity = repo.update(id, newExpense).orElseThrow(() -> createExpenseNotFoundException(id));
+        return new UpdateExpenseResponse(ExpenseMapper.toDto(updatedEntity));
+    }
 
     private void expenseWriteValidations(Expense expense) {
         if (expense.expenseDate() == null) {
@@ -72,7 +98,7 @@ public class ExpenseService {
         Account account = accountService.getById(expense.accountId());
         
         if (!account.createdBy().equals(expense.createdBy())) {
-            throw createUnauthorizedAccountException("User does not own the given account");
+            throw createUnauthorizedExpenseException("User does not own the given account");
         }
     }
 }

--- a/src/test/java/com/novelosoftware/expenses/controllers/AccountControllerTest.java
+++ b/src/test/java/com/novelosoftware/expenses/controllers/AccountControllerTest.java
@@ -41,7 +41,7 @@ class AccountControllerTest {
     @Test
     void getByUser_returnsPaginatedAccounts() throws Exception {
         var page = new PageResponse<>(List.of(anAccount(1L)), 0, 20, 1L, 1);
-        when(service.getByUser("user-1", 0, 20)).thenReturn(page);
+        when(service.findByUser("user-1", 0, 20)).thenReturn(page);
 
         mockMvc.perform(get("/accounts/user/user-1"))
             .andExpect(status().isOk())

--- a/src/test/java/com/novelosoftware/expenses/controllers/ExpenseControllerTest.java
+++ b/src/test/java/com/novelosoftware/expenses/controllers/ExpenseControllerTest.java
@@ -1,6 +1,7 @@
 package com.novelosoftware.expenses.controllers;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -27,6 +28,8 @@ import com.novelosoftware.expenses.dto.CreateExpenseRequest;
 import com.novelosoftware.expenses.dto.CreateExpenseResponse;
 import com.novelosoftware.expenses.dto.Expense;
 import com.novelosoftware.expenses.dto.SubCategory;
+import com.novelosoftware.expenses.dto.UpdateExpenseRequest;
+import com.novelosoftware.expenses.dto.UpdateExpenseResponse;
 import com.novelosoftware.expenses.exceptions.ExpenseServiceExceptions;
 import com.novelosoftware.expenses.exceptions.GlobalExceptionHandler;
 import com.novelosoftware.expenses.services.ExpenseService;
@@ -38,9 +41,23 @@ import com.novelosoftware.expenses.services.ExpenseService;
 @Import(GlobalExceptionHandler.class)
 public class ExpenseControllerTest {
     
-    private static final String PAYLOAD = """
+    private static final String CREATE_PAYLOAD = """
                     {
                         "value": {
+                            "expenseDate": "2026-05-25",
+                            "accountId": 1,
+                            "amount": 1000.00,
+                            "description": "Expensive Tacos",
+                            "subCategory": "RESTAURANT",
+                            "createdBy": "user-1"
+                        }
+                    }
+                """;
+
+    private static final String UPDATE_PAYLOAD = """
+                    {
+                        "value": {
+                            "expenseId": 1,
                             "expenseDate": "2026-05-25",
                             "accountId": 1,
                             "amount": 1000.00,
@@ -62,7 +79,7 @@ public class ExpenseControllerTest {
         when(expenseService.create(any())).thenReturn(new CreateExpenseResponse(anExpense(1L)));
         mockMvc.perform(post("/expenses")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(PAYLOAD))
+                .content(CREATE_PAYLOAD))
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.value.expenseId").value(1))
             .andExpect(jsonPath("$.value.expenseDate").value("2026-05-25"))
@@ -92,6 +109,43 @@ public class ExpenseControllerTest {
         verifyNoInteractions(expenseService);
     }
 
+    @Test
+    void update_testHappyPath() throws Exception {
+        when(expenseService.update(anyLong(), any(UpdateExpenseRequest.class)))
+            .thenReturn(new UpdateExpenseResponse(anExpense(1L)));
+        mockMvc.perform(put("/expenses/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(UPDATE_PAYLOAD))
+            .andExpect(status().is2xxSuccessful())
+            .andExpect(jsonPath("$.value.expenseId").value(1))
+            .andExpect(jsonPath("$.value.expenseDate").value("2026-05-25"))
+            .andExpect(jsonPath("$.value.accountId").value(1))
+            .andExpect(jsonPath("$.value.amount").value(1000.00))
+            .andExpect(jsonPath("$.value.description").value("Expensive Tacos"));
+
+        verify(expenseService).update(1L, new UpdateExpenseRequest(anExpense(1L)));
+    }
+
+    @Test
+    void update_testMalformedJSON() throws Exception {
+        mockMvc.perform(put("/expenses/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                        "values": {
+                            "expenseId": 1
+                            "expenseDate": "2026-05-25",
+                            "accountId": 1,
+                            "amount": 1000.00,
+                            "description": "Expensive Tacos",
+                            "subCategory": "RESTAURANT",
+                            "createdBy": "user-1"
+                        }
+                """))
+            .andExpect(status().isBadRequest());
+        verifyNoInteractions(expenseService);
+    }
+
     @ParameterizedTest(name = "create_invalidExpense-{0}")
     @MethodSource("serviceExcptions")
     void create_invalidExpense(String testName, RuntimeException exception, ResultMatcher statusMatcher) throws Exception {
@@ -99,7 +153,18 @@ public class ExpenseControllerTest {
                 .thenThrow(exception);
         mockMvc.perform(post("/expenses")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(PAYLOAD))
+                .content(CREATE_PAYLOAD))
+            .andExpect(statusMatcher);
+    }
+
+    @ParameterizedTest(name = "update_invalidExpense-{0}")
+    @MethodSource("serviceExcptions")
+    void update_invalidExpense(String testName, RuntimeException exception, ResultMatcher statusMatcher) throws Exception {
+        when(expenseService.update(anyLong(), any(UpdateExpenseRequest.class)))
+                .thenThrow(exception);
+        mockMvc.perform(put("/expenses/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(UPDATE_PAYLOAD))
             .andExpect(statusMatcher);
     }
 
@@ -107,7 +172,7 @@ public class ExpenseControllerTest {
         return Stream.of(
             Arguments.of(
                 "unauthorized", 
-                ExpenseServiceExceptions.createUnauthorizedAccountException("forbidden"), 
+                ExpenseServiceExceptions.createUnauthorizedExpenseException("forbidden"), 
                 status().isForbidden()),
             Arguments.of(
                 "bad_request", 

--- a/src/test/java/com/novelosoftware/expenses/repositories/ExpenseRepositoryTest.java
+++ b/src/test/java/com/novelosoftware/expenses/repositories/ExpenseRepositoryTest.java
@@ -188,6 +188,28 @@ class ExpenseRepositoryTest {
     }
 
     // -------------------------------------------------------------------------
+    // Get
+    // -------------------------------------------------------------------------
+
+    @Test
+    void get_happyPath() {
+        var id = 1L;
+        when(jdbc.query(ExpenseRepository.GET_SQL, ExpenseRepository.MAPPER, id))
+            .thenReturn(List.of(anEntity(id)));
+        
+        assertTrue(repo.get(id).isPresent());
+    }
+
+    @Test
+    void get_notFound() {
+        var id = 1L;
+        when(jdbc.query(ExpenseRepository.GET_SQL, ExpenseRepository.MAPPER, id))
+            .thenReturn(List.of());
+        
+        assertTrue(repo.get(id).isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
     // Helper
     // -------------------------------------------------------------------------
 

--- a/src/test/java/com/novelosoftware/expenses/services/AccountServiceTest.java
+++ b/src/test/java/com/novelosoftware/expenses/services/AccountServiceTest.java
@@ -62,7 +62,7 @@ class AccountServiceTest {
         when(repo.findByUser("user-1", 20, 0)).thenReturn(List.of(anEntity(1L)));
         when(repo.countByUser("user-1")).thenReturn(1L);
 
-        var result = service.getByUser("user-1", 0, 20);
+        var result = service.findByUser("user-1", 0, 20);
 
         assertEquals(1, result.content().size());
         assertEquals(1L, result.totalElements());

--- a/src/test/java/com/novelosoftware/expenses/services/ExpenseServiceTest.java
+++ b/src/test/java/com/novelosoftware/expenses/services/ExpenseServiceTest.java
@@ -2,10 +2,14 @@ package com.novelosoftware.expenses.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -23,9 +27,11 @@ import com.novelosoftware.expenses.dto.CreateExpenseRequest;
 import com.novelosoftware.expenses.dto.CreateExpenseResponse;
 import com.novelosoftware.expenses.dto.Expense;
 import com.novelosoftware.expenses.dto.SubCategory;
+import com.novelosoftware.expenses.dto.UpdateExpenseRequest;
+import com.novelosoftware.expenses.dto.UpdateExpenseResponse;
 import com.novelosoftware.expenses.entities.ExpenseEntity;
 import com.novelosoftware.expenses.exceptions.ExpenseServiceExceptions.ExpenseValidationException;
-import com.novelosoftware.expenses.exceptions.ExpenseServiceExceptions.UnauthorizedAccountException;
+import com.novelosoftware.expenses.exceptions.ExpenseServiceExceptions.UnauthorizedExpenseException;
 import com.novelosoftware.expenses.mappers.CategoryMapper;
 import com.novelosoftware.expenses.repositories.ExpenseRepository;
 
@@ -34,11 +40,15 @@ import com.novelosoftware.expenses.repositories.ExpenseRepository;
  */
 @ExtendWith(MockitoExtension.class)
 public class ExpenseServiceTest {
-    
+
+    private static final Long EXPENSE_ID = 31416L;
+
+    private static final Long ACCOUNT_ID = 543412L;
+
     private static final Expense VALID_NEW_EXPENSE = new Expense(
         null, 
         LocalDate.of(2026, 5, 25),
-        1L,
+        ACCOUNT_ID,
         new BigDecimal("1000.00"), 
         "Expensive Tacos", 
         SubCategory.RESTAURANT, 
@@ -47,7 +57,7 @@ public class ExpenseServiceTest {
     private static final ExpenseEntity MAPPEED_ENTITY = new ExpenseEntity(
         null, 
         LocalDate.of(2026, 5, 25),
-        1L,
+        ACCOUNT_ID,
         new BigDecimal("1000.00"), 
         "Expensive Tacos", 
         CategoryMapper.getCategory(SubCategory.RESTAURANT).name(),
@@ -55,9 +65,9 @@ public class ExpenseServiceTest {
         "user-1");
 
     private static final ExpenseEntity CREATED_ENTITY = new ExpenseEntity(
-        1L, 
+        EXPENSE_ID, 
         LocalDate.of(2026, 5, 25),
-        1L,
+        ACCOUNT_ID,
         new BigDecimal("1000.00"), 
         "Expensive Tacos", 
         CategoryMapper.getCategory(SubCategory.RESTAURANT).name(),
@@ -65,22 +75,27 @@ public class ExpenseServiceTest {
         "user-1");
 
     private static final Expense CREATED_DTO = new Expense(
-        1L, 
+        EXPENSE_ID, 
         LocalDate.of(2026, 5, 25),
-        1L,
+        ACCOUNT_ID,
         new BigDecimal("1000.00"), 
         "Expensive Tacos", 
         SubCategory.RESTAURANT,
         "user-1");
 
     private static final Account VALID_ACCOUNT = new Account(
-        1L,
+        ACCOUNT_ID,
         "Debit account",
         AccountType.DEBIT,
         "USD",
         new BigDecimal("1000.00"),
         new BigDecimal("900.00"),
         "user-1");
+
+    private static final Expense UPDATED_EXPENSE = VALID_NEW_EXPENSE.toBuilder()
+        .expenseId(EXPENSE_ID)
+        .amount(new BigDecimal("100.00"))
+        .build();
 
     @Mock
     ExpenseRepository repo;
@@ -103,25 +118,73 @@ public class ExpenseServiceTest {
     @Test
     void create_invalidAccount() {
         CreateExpenseRequest request = new CreateExpenseRequest(VALID_NEW_EXPENSE);
-        when(accountService.getById(VALID_NEW_EXPENSE.accountId())).thenReturn(new Account(
-            1L,
-            "Debit account",
-            AccountType.DEBIT,
-            "USD",
-            new BigDecimal("1000.00"),
-            new BigDecimal("900.00"),
-            "user-2"));
+        when(accountService.getById(VALID_NEW_EXPENSE.accountId())).thenReturn(VALID_ACCOUNT.toBuilder()
+            .createdBy("user-2")
+            .build());
         
-        assertThrows(UnauthorizedAccountException.class, () -> service.create(request));
+        assertThrows(UnauthorizedExpenseException.class, () -> service.create(request));
     }
 
+    @Test 
+    void update_happyPath() {
+        ExpenseEntity existingExpense = MAPPEED_ENTITY.toBuilder()
+            .expenseId(EXPENSE_ID)
+            .build();
 
+        ExpenseEntity updatedExpenseEntity = existingExpense.toBuilder()
+            .amount(new BigDecimal("100.00"))
+            .build();
+        
+        when(accountService.getById(anyLong())).thenReturn(VALID_ACCOUNT);
+        when(repo.get(anyLong())).thenReturn(Optional.of(existingExpense));
+        when(repo.update(anyLong(), any(ExpenseEntity.class))).thenReturn(Optional.of(updatedExpenseEntity));
+
+        UpdateExpenseResponse actual = service.update(EXPENSE_ID, new UpdateExpenseRequest(UPDATED_EXPENSE));
+
+        assertEquals(UPDATED_EXPENSE, actual.value());
+        verify(accountService).getById(ACCOUNT_ID);
+        verify(repo).get(EXPENSE_ID);
+        verify(repo).update(EXPENSE_ID, updatedExpenseEntity);
+    }
+
+    @Test
+    void update_testInvalidAccount() {
+        when(accountService.getById(VALID_NEW_EXPENSE.accountId())).thenReturn(VALID_ACCOUNT.toBuilder()
+            .createdBy("user-2")
+            .build());
+
+        assertThrows(UnauthorizedExpenseException.class, () -> service.update(
+            EXPENSE_ID, new UpdateExpenseRequest(UPDATED_EXPENSE)));
+    }
+
+    @Test 
+    void update_unauthorizedExpense() {
+        ExpenseEntity existingExpense = MAPPEED_ENTITY.toBuilder()
+            .expenseId(EXPENSE_ID)
+            .createdBy("user-2")
+            .build();
+        
+        when(accountService.getById(anyLong())).thenReturn(VALID_ACCOUNT);
+        when(repo.get(anyLong())).thenReturn(Optional.of(existingExpense));
+
+       assertThrows(UnauthorizedExpenseException.class, () -> service.update(EXPENSE_ID, new UpdateExpenseRequest(UPDATED_EXPENSE)));
+
+        verify(accountService).getById(ACCOUNT_ID);
+        verify(repo).get(EXPENSE_ID);
+    }
 
     @ParameterizedTest(name = "create_testInvalidInputs-{0}")
     @MethodSource("invalidExpenses")
     void create_testInvalidInputs(String testName, Expense expense) {
         CreateExpenseRequest request = new CreateExpenseRequest(expense);
         assertThrows(ExpenseValidationException.class, () -> service.create(request));
+    }
+
+    @ParameterizedTest(name = "update_testInvalidInputs-{0}")
+    @MethodSource("invalidExpenses")
+    void update_testInvalidInputs(String testName, Expense expense) {
+        UpdateExpenseRequest updateExpenseRequest = new UpdateExpenseRequest(expense);
+        assertThrows(ExpenseValidationException.class, () -> service.update(EXPENSE_ID, updateExpenseRequest));
     }
 
     static Stream<Arguments> invalidExpenses() {
@@ -131,7 +194,7 @@ public class ExpenseServiceTest {
                 new Expense(
                     null, 
                     null,
-                    1L,
+                    ACCOUNT_ID,
                     new BigDecimal("1000.00"), 
                     "Expensive Tacos", 
                     SubCategory.RESTAURANT, 
@@ -151,7 +214,7 @@ public class ExpenseServiceTest {
                 new Expense(
                     null, 
                     LocalDate.of(2026, 5, 25),
-                    1L,
+                    ACCOUNT_ID,
                     null, 
                     "Expensive Tacos", 
                     SubCategory.RESTAURANT, 
@@ -161,7 +224,7 @@ public class ExpenseServiceTest {
                 new Expense(
                     null, 
                     LocalDate.of(2026, 5, 25),
-                    1L,
+                    ACCOUNT_ID,
                     new BigDecimal("1000.00"), 
                     null, 
                     SubCategory.RESTAURANT, 
@@ -171,7 +234,7 @@ public class ExpenseServiceTest {
                 new Expense(
                     null, 
                     LocalDate.of(2026, 5, 25),
-                    1L,
+                    ACCOUNT_ID,
                     new BigDecimal("1000.00"), 
                     "", 
                     SubCategory.RESTAURANT, 
@@ -181,7 +244,7 @@ public class ExpenseServiceTest {
                 new Expense(
                     null, 
                     LocalDate.of(2026, 5, 25),
-                    1L,
+                    ACCOUNT_ID,
                     new BigDecimal("1000.00"), 
                     "Expensive Tacos", 
                     null, 
@@ -191,7 +254,7 @@ public class ExpenseServiceTest {
                 new Expense(
                     null, 
                     LocalDate.of(2026, 5, 25),
-                    1L,
+                    ACCOUNT_ID,
                     new BigDecimal("1000.00"), 
                     "Expensive Tacos", 
                     SubCategory.RESTAURANT, 
@@ -201,7 +264,7 @@ public class ExpenseServiceTest {
                 new Expense(
                     null, 
                     LocalDate.of(2026, 5, 25),
-                    1L,
+                    ACCOUNT_ID,
                     new BigDecimal("1000.00"), 
                     "Expensive Tacos", 
                     SubCategory.RESTAURANT, 


### PR DESCRIPTION
## Summary

- Add `builder()` / `toBuilder()` pattern to all DTO records (`Account`, `Expense`, `PageResponse`, and all request/response wrappers) and internal entity records (`AccountEntity`, `ExpenseEntity`)
- Add `PUT /expenses/{id}` update endpoint backed by `ExpenseService#update`
- Add `ExpenseNotFoundException` and `UnauthorizedExpenseException` with global handler mappings
- Expand unit and integration test coverage for the new update flow

## Test plan

- [x] `./gradlew test` — all unit tests pass
- [x] `./gradlew integrationTest` — `ExpenseControllerIT` covers the new PUT endpoint
- [x] Verify builder/toBuilder usage compiles and behaves correctly in mapper/service code

🤖 Generated with [Claude Code](https://claude.com/claude-code)