### PR TITLE
Add GET /expenses/{id} and DELETE /expenses/{id}

### DIFF
--- a/openspec/changes/archive/2026-06-06-add-expense-get-delete/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-06-add-expense-get-delete/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/archive/2026-06-06-add-expense-get-delete/design.md
+++ b/openspec/changes/archive/2026-06-06-add-expense-get-delete/design.md
@@ -1,0 +1,31 @@
+## Context
+
+The expenses API has `POST /expenses` (create) and `PUT /expenses/{id}` (update) but is missing `GET /expenses/{id}` and `DELETE /expenses/{id}`. The existing stack is Spring Boot with `spring-boot-starter-jdbc`; all queries are plain SQL executed via `JdbcTemplate`. Notably, `ExpenseRepository` already has `get(Long id)` and `delete(Long id)` implemented — only the service and controller layers need to be added.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `GET /expenses/{id}` returning the full `Expense` DTO
+- Add `DELETE /expenses/{id}` returning 204 No Content
+- Return 404 when the requested ID does not exist (both endpoints)
+
+**Non-Goals:**
+- Soft delete / audit trail (permanent hard delete only)
+- Bulk delete
+- Authorization checks beyond what the existing endpoints enforce
+
+## Decisions
+
+**Reuse `ExpenseNotFoundException`**: The existing `ExpenseServiceExceptions` pattern (e.g. for update) will be extended with a not-found exception that the `GlobalExceptionHandler` maps to 404. No new exception infrastructure needed.
+
+**No new DTO**: `GET /expenses/{id}` returns the existing `Expense` record directly (same shape as list items). Wrapping it in a response object would be inconsistent with the list endpoint and add noise.
+
+**Hard delete**: The data model has no `deleted_at` column and there is no stated requirement for audit history, so a hard `DELETE` via `deleteById` is the right call. Soft delete can be added later if needed.
+
+## Risks / Trade-offs
+
+- [Orphaned references] Deleting an expense that is referenced by external systems (reports, exports) will produce dangling IDs → Acceptable at this stage; callers are expected to handle 404 on stale IDs.
+
+## Migration Plan
+
+No schema changes required. Deploy is a drop-in addition of two endpoints.

--- a/openspec/changes/archive/2026-06-06-add-expense-get-delete/proposal.md
+++ b/openspec/changes/archive/2026-06-06-add-expense-get-delete/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The expenses API currently supports creating and updating expenses but has no way to fetch a single expense by ID or delete one. This leaves the CRUD surface incomplete — callers must page through list results to retrieve a known expense and have no recourse for removing erroneous entries.
+
+## What Changes
+
+- Add `GET /expenses/{id}` — returns a single expense by its ID
+- Add `DELETE /expenses/{id}` — removes an expense by its ID, returning 204 No Content
+
+## Capabilities
+
+### New Capabilities
+- `get-expense-by-id`: Fetch a single expense by its numeric ID
+- `delete-expense`: Delete an expense by its numeric ID
+
+### Modified Capabilities
+<!-- none -->
+
+## Impact
+
+- `ExpenseController` — two new endpoint methods
+- `ExpenseService` — two new service methods
+- `ExpenseRepository` — uses existing JPA `findById` / `deleteById`
+- New exception type for expense-not-found (404)
+- Integration tests for both endpoints

--- a/openspec/changes/archive/2026-06-06-add-expense-get-delete/specs/delete-expense/spec.md
+++ b/openspec/changes/archive/2026-06-06-add-expense-get-delete/specs/delete-expense/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Delete expense by ID
+The system SHALL expose a `DELETE /expenses/{id}` endpoint that permanently removes the expense with the given numeric ID.
+
+#### Scenario: Expense deleted successfully
+- **WHEN** a caller sends `DELETE /expenses/{id}` with a valid existing expense ID
+- **THEN** the system deletes the expense and returns HTTP 204 with no response body
+
+#### Scenario: Expense not found
+- **WHEN** a caller sends `DELETE /expenses/{id}` with an ID that does not exist
+- **THEN** the system returns HTTP 404 with an appropriate error message
+
+#### Scenario: Invalid ID format
+- **WHEN** a caller sends `DELETE /expenses/{id}` where `id` is not a valid number
+- **THEN** the system returns HTTP 400

--- a/openspec/changes/archive/2026-06-06-add-expense-get-delete/specs/get-expense-by-id/spec.md
+++ b/openspec/changes/archive/2026-06-06-add-expense-get-delete/specs/get-expense-by-id/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Fetch single expense by ID
+The system SHALL expose a `GET /expenses/{id}` endpoint that returns the full expense record for the given numeric ID.
+
+#### Scenario: Expense exists
+- **WHEN** a caller sends `GET /expenses/{id}` with a valid existing expense ID
+- **THEN** the system returns HTTP 200 with the `Expense` JSON object
+
+#### Scenario: Expense not found
+- **WHEN** a caller sends `GET /expenses/{id}` with an ID that does not exist
+- **THEN** the system returns HTTP 404 with an appropriate error message
+
+#### Scenario: Invalid ID format
+- **WHEN** a caller sends `GET /expenses/{id}` where `id` is not a valid number
+- **THEN** the system returns HTTP 400

--- a/openspec/changes/archive/2026-06-06-add-expense-get-delete/tasks.md
+++ b/openspec/changes/archive/2026-06-06-add-expense-get-delete/tasks.md
@@ -1,0 +1,27 @@
+## 1. Exception Handling
+
+- [x] 1.1 Add `ExpenseNotFoundException` (or reuse existing pattern in `ExpenseServiceExceptions`) mapped to HTTP 404 in `GlobalExceptionHandler`
+
+## 2. Service Layer
+
+- [x] 2.1 Add `getById(Long id)` to `ExpenseService` — call `repository.get(id)`, throw not-found exception if empty, map to `Expense` DTO
+- [x] 2.2 Add `delete(Long id)` to `ExpenseService` — call `repository.delete(id)`, throw not-found exception if it returns `false`
+
+## 3. Controller Layer
+
+- [x] 3.1 Add `GET /expenses/{id}` endpoint to `ExpenseController` returning `Expense` (200)
+- [x] 3.2 Add `DELETE /expenses/{id}` endpoint to `ExpenseController` returning 204 No Content
+
+## 4. Unit Tests
+
+- [x] 4.1 Add `ExpenseServiceTest` cases for `getById`: found and not-found
+- [x] 4.2 Add `ExpenseServiceTest` cases for `delete`: success and not-found
+- [x] 4.3 Add `ExpenseControllerTest` cases for `GET /expenses/{id}`: 200 and 404
+- [x] 4.4 Add `ExpenseControllerTest` cases for `DELETE /expenses/{id}`: 204 and 404
+
+## 5. Integration Tests
+
+- [x] 5.1 Add `ExpenseControllerIT` test for `GET /expenses/{id}` — existing expense returns 200 with correct body
+- [x] 5.2 Add `ExpenseControllerIT` test for `GET /expenses/{id}` — unknown ID returns 404
+- [x] 5.3 Add `ExpenseControllerIT` test for `DELETE /expenses/{id}` — existing expense returns 204 and is no longer retrievable
+- [x] 5.4 Add `ExpenseControllerIT` test for `DELETE /expenses/{id}` — unknown ID returns 404

--- a/openspec/specs/delete-expense/spec.md
+++ b/openspec/specs/delete-expense/spec.md
@@ -1,0 +1,22 @@
+# Spec: Delete Expense
+
+## Purpose
+
+Permanently remove an expense record by its numeric ID via the `DELETE /expenses/{id}` endpoint.
+
+## Requirements
+
+### Requirement: Delete expense by ID
+The system SHALL expose a `DELETE /expenses/{id}` endpoint that permanently removes the expense with the given numeric ID.
+
+#### Scenario: Expense deleted successfully
+- **WHEN** a caller sends `DELETE /expenses/{id}` with a valid existing expense ID
+- **THEN** the system deletes the expense and returns HTTP 204 with no response body
+
+#### Scenario: Expense not found
+- **WHEN** a caller sends `DELETE /expenses/{id}` with an ID that does not exist
+- **THEN** the system returns HTTP 404 with an appropriate error message
+
+#### Scenario: Invalid ID format
+- **WHEN** a caller sends `DELETE /expenses/{id}` where `id` is not a valid number
+- **THEN** the system returns HTTP 400

--- a/openspec/specs/get-expense-by-id/spec.md
+++ b/openspec/specs/get-expense-by-id/spec.md
@@ -1,0 +1,22 @@
+# Spec: Get Expense by ID
+
+## Purpose
+
+Retrieve a single expense record by its numeric ID via the `GET /expenses/{id}` endpoint.
+
+## Requirements
+
+### Requirement: Fetch single expense by ID
+The system SHALL expose a `GET /expenses/{id}` endpoint that returns the full expense record for the given numeric ID.
+
+#### Scenario: Expense exists
+- **WHEN** a caller sends `GET /expenses/{id}` with a valid existing expense ID
+- **THEN** the system returns HTTP 200 with the `Expense` JSON object
+
+#### Scenario: Expense not found
+- **WHEN** a caller sends `GET /expenses/{id}` with an ID that does not exist
+- **THEN** the system returns HTTP 404 with an appropriate error message
+
+#### Scenario: Invalid ID format
+- **WHEN** a caller sends `GET /expenses/{id}` where `id` is not a valid number
+- **THEN** the system returns HTTP 400

--- a/src/integrationTest/java/com/novelosoftware/expenses/controllers/ExpenseControllerIT.java
+++ b/src/integrationTest/java/com/novelosoftware/expenses/controllers/ExpenseControllerIT.java
@@ -11,6 +11,7 @@ import java.time.YearMonth;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -583,6 +584,47 @@ class ExpenseControllerIT extends BaseIT {
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.code").value("NOT_FOUND"))
             .andExpect(jsonPath("$.message").value("Expense id 999999 not found"));
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /expenses/{id}
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getById_existingExpense_returns200WithBody() throws Exception {
+        long expenseId = createExpense(firstAccountId, USER);
+        mockMvc.perform(get("/expenses/" + expenseId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.expenseId").value(expenseId))
+            .andExpect(jsonPath("$.accountId").value(firstAccountId))
+            .andExpect(jsonPath("$.createdBy").value(USER));
+    }
+
+    @Test
+    void getById_unknownId_returns404() throws Exception {
+        mockMvc.perform(get("/expenses/999999"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    // -------------------------------------------------------------------------
+    // DELETE /expenses/{id}
+    // -------------------------------------------------------------------------
+
+    @Test
+    void delete_existingExpense_returns204AndIsGone() throws Exception {
+        long expenseId = createExpense(firstAccountId, USER);
+        mockMvc.perform(delete("/expenses/" + expenseId))
+            .andExpect(status().isNoContent());
+        mockMvc.perform(get("/expenses/" + expenseId))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void delete_unknownId_returns404() throws Exception {
+        mockMvc.perform(delete("/expenses/999999"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("NOT_FOUND"));
     }
 
     @Test

--- a/src/main/java/com/novelosoftware/expenses/controllers/ExpenseController.java
+++ b/src/main/java/com/novelosoftware/expenses/controllers/ExpenseController.java
@@ -2,6 +2,7 @@ package com.novelosoftware.expenses.controllers;
 
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -76,6 +77,17 @@ public class ExpenseController {
     @ResponseStatus(HttpStatus.CREATED)
     public CreateExpenseResponse create(@RequestBody CreateExpenseRequest request) {
         return expenseService.create(request);
+    }
+
+    @GetMapping("/{id}")
+    public Expense getById(@PathVariable Long id) {
+        return expenseService.getById(id);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        expenseService.delete(id);
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/novelosoftware/expenses/services/ExpenseService.java
+++ b/src/main/java/com/novelosoftware/expenses/services/ExpenseService.java
@@ -63,6 +63,17 @@ public class ExpenseService {
         return new CreateExpenseResponse(ExpenseMapper.toDto(createdEntity));
     }
 
+    public Expense getById(Long id) {
+        ExpenseEntity entity = repo.get(id).orElseThrow(() -> createExpenseNotFoundException(id));
+        return ExpenseMapper.toDto(entity);
+    }
+
+    public void delete(Long id) {
+        if (!repo.delete(id)) {
+            throw createExpenseNotFoundException(id);
+        }
+    }
+
     public UpdateExpenseResponse update(Long id, UpdateExpenseRequest request) {
         if (request == null || request.value() == null)  {
             throw createValidationException("Expense payload not provided");

--- a/src/test/java/com/novelosoftware/expenses/controllers/ExpenseControllerTest.java
+++ b/src/test/java/com/novelosoftware/expenses/controllers/ExpenseControllerTest.java
@@ -7,6 +7,8 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -76,6 +78,48 @@ public class ExpenseControllerTest {
 
     @MockitoBean
     private ExpenseService expenseService;
+
+    // -------------------------------------------------------------------------
+    // GET /expenses/{id}
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getById_found_returns200() throws Exception {
+        when(expenseService.getById(1L)).thenReturn(anExpense(1L));
+        mockMvc.perform(get("/expenses/1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.expenseId").value(1))
+            .andExpect(jsonPath("$.description").value("Expensive Tacos"));
+    }
+
+    @Test
+    void getById_notFound_returns404() throws Exception {
+        when(expenseService.getById(999L))
+            .thenThrow(ExpenseServiceExceptions.createExpenseNotFoundException(999L));
+        mockMvc.perform(get("/expenses/999"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    // -------------------------------------------------------------------------
+    // DELETE /expenses/{id}
+    // -------------------------------------------------------------------------
+
+    @Test
+    void delete_success_returns204() throws Exception {
+        doNothing().when(expenseService).delete(1L);
+        mockMvc.perform(delete("/expenses/1"))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void delete_notFound_returns404() throws Exception {
+        doThrow(ExpenseServiceExceptions.createExpenseNotFoundException(999L))
+            .when(expenseService).delete(999L);
+        mockMvc.perform(delete("/expenses/999"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
 
     @Test
     void create_testHappyPath() throws Exception {

--- a/src/test/java/com/novelosoftware/expenses/services/ExpenseServiceTest.java
+++ b/src/test/java/com/novelosoftware/expenses/services/ExpenseServiceTest.java
@@ -42,6 +42,7 @@ import com.novelosoftware.expenses.dto.SubCategory;
 import com.novelosoftware.expenses.dto.UpdateExpenseRequest;
 import com.novelosoftware.expenses.dto.UpdateExpenseResponse;
 import com.novelosoftware.expenses.entities.ExpenseEntity;
+import com.novelosoftware.expenses.exceptions.ExpenseServiceExceptions.ExpenseNotFoundException;
 import com.novelosoftware.expenses.exceptions.ExpenseServiceExceptions.ExpenseValidationException;
 import com.novelosoftware.expenses.exceptions.ExpenseServiceExceptions.InvalidCursorException;
 import com.novelosoftware.expenses.exceptions.ExpenseServiceExceptions.UnauthorizedExpenseException;
@@ -131,6 +132,41 @@ public class ExpenseServiceTest {
     @BeforeEach
     void setUp() {
         service = new ExpenseService(repo, accountService, FIXED_CLOCK);
+    }
+
+    // -------------------------------------------------------------------------
+    // getById
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getById_found_returnsMappedDto() {
+        when(repo.get(EXPENSE_ID)).thenReturn(Optional.of(CREATED_ENTITY));
+        Expense result = service.getById(EXPENSE_ID);
+        assertEquals(CREATED_DTO, result);
+        verify(repo).get(EXPENSE_ID);
+    }
+
+    @Test
+    void getById_notFound_throwsExpenseNotFoundException() {
+        when(repo.get(EXPENSE_ID)).thenReturn(Optional.empty());
+        assertThrows(ExpenseNotFoundException.class, () -> service.getById(EXPENSE_ID));
+    }
+
+    // -------------------------------------------------------------------------
+    // delete
+    // -------------------------------------------------------------------------
+
+    @Test
+    void delete_success_doesNotThrow() {
+        when(repo.delete(EXPENSE_ID)).thenReturn(true);
+        service.delete(EXPENSE_ID);
+        verify(repo).delete(EXPENSE_ID);
+    }
+
+    @Test
+    void delete_notFound_throwsExpenseNotFoundException() {
+        when(repo.delete(EXPENSE_ID)).thenReturn(false);
+        assertThrows(ExpenseNotFoundException.class, () -> service.delete(EXPENSE_ID));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Adds `GET /expenses/{id}` — returns a single expense by ID (200) or 404 if not found
- Adds `DELETE /expenses/{id}` — deletes an expense (204) or 404 if not found
- `ExpenseRepository` already had `get()` and `delete()` implemented; only the service and controller layers were added

## What changed

**Service** (`ExpenseService`): `getById(Long id)` and `delete(Long id)` — both delegate to the existing repository methods and throw `ExpenseNotFoundException` (→ 404) when the row doesn't exist.

**Controller** (`ExpenseController`): `GET /{id}` returning `Expense` directly, `DELETE /{id}` returning 204 No Content.

## Test plan

- [x] `ExpenseServiceTest` — `getById` found/not-found, `delete` success/not-found (unit)
- [x] `ExpenseControllerTest` — 200/404 for GET, 204/404 for DELETE (unit, MockMvc)
- [x] `ExpenseControllerIT` — GET existing expense returns correct body; GET unknown returns 404; DELETE removes expense and subsequent GET returns 404; DELETE unknown returns 404 (integration, Testcontainers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)