### PR TITLE
Add GET /accounts/{id}/expenses nested route

### DIFF
--- a/openspec/changes/add-account-expenses-route/.openspec.yaml
+++ b/openspec/changes/add-account-expenses-route/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/add-account-expenses-route/design.md
+++ b/openspec/changes/add-account-expenses-route/design.md
@@ -1,0 +1,33 @@
+## Context
+
+`GET /expenses?account_id={id}` already supports filtering by account, but requires callers to also pass `user_id`. The nested route `GET /accounts/{id}/expenses` can resolve the owner internally by loading the account, making it a more ergonomic shortcut without duplicating any query logic.
+
+The stack is Spring Boot with `JdbcTemplate`. All expense queries go through `ExpenseService.listByUser`, which requires a `userId`. `AccountService.getById` can supply that value from the account record's `createdBy` field.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `GET /accounts/{id}/expenses` with full filter/pagination parity to `GET /expenses`
+- Resolve `user_id` automatically from the account — callers do not pass it
+- Return 404 when the account does not exist
+
+**Non-Goals:**
+- Replacing or deprecating `GET /expenses?account_id=`
+- Cross-user expense queries (the endpoint is scoped to the account owner)
+- Any new query logic — this is a routing convenience on top of existing service code
+
+## Decisions
+
+**Resolve user from account, not from a request param**: Callers of this route already know which account they want; requiring them to also pass `user_id` would be redundant. `AccountService.getById` throws `AccountNotFoundException` (404) if the account is absent, which is the correct error for a bad path param.
+
+**Place the endpoint on `AccountController`**: The path is `/accounts/{id}/expenses`, so it lives naturally in `AccountController`. It injects `ExpenseService` (or delegates through a shared service call) to keep the boundary clear.
+
+**Reuse `ExpenseService.listByUser` unchanged**: The method already accepts `accountId` as an optional filter and `userId` as mandatory. We pass both — `userId` from the resolved account, `accountId` from the path — so the DB query is identical to the existing filter path. No new repository method needed.
+
+## Risks / Trade-offs
+
+- [Tight coupling between AccountController and ExpenseService] AccountController now depends on ExpenseService → Acceptable; the dependency is one-directional and the use case is well-defined. Alternative (a dedicated `AccountExpenseService`) would be over-engineering for a single delegating method.
+
+## Migration Plan
+
+No schema changes. Deploy is additive — existing clients are unaffected.

--- a/openspec/changes/add-account-expenses-route/proposal.md
+++ b/openspec/changes/add-account-expenses-route/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+`GET /expenses?account_id={id}` works but requires callers to know the filter parameter name and always pass a user_id. A nested route `GET /accounts/{id}/expenses` is a more natural REST pattern for the common case of "show me all expenses on this account."
+
+## What Changes
+
+- Add `GET /accounts/{id}/expenses` — lists expenses scoped to a specific account, with the same pagination, date-window, and category/subcategory filter support as the existing list endpoint
+
+## Capabilities
+
+### New Capabilities
+- `list-expenses-by-account`: Paginated expense list scoped to an account ID, supporting cursor pagination, date window, and category/subcategory filters
+
+### Modified Capabilities
+<!-- none -->
+
+## Impact
+
+- `AccountController` — one new endpoint method
+- `ExpenseService` — reuses existing `listByUser` logic; `account_id` is mandatory, `user_id` is inferred from the account
+- `AccountService.getById` — called to resolve the account owner (validates account exists and provides the `createdBy` user)
+- No schema changes

--- a/openspec/changes/add-account-expenses-route/specs/list-expenses-by-account/spec.md
+++ b/openspec/changes/add-account-expenses-route/specs/list-expenses-by-account/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: List expenses by account
+The system SHALL expose `GET /accounts/{id}/expenses` that returns a cursor-paginated list of expenses belonging to the given account, supporting the same date-window, limit, cursor, category, and subcategory filters as `GET /expenses`.
+
+#### Scenario: Account exists with expenses
+- **WHEN** a caller sends `GET /accounts/{id}/expenses` for an account that has expenses in the requested date window
+- **THEN** the system returns HTTP 200 with a paginated list of expenses for that account
+
+#### Scenario: Account exists with no expenses
+- **WHEN** a caller sends `GET /accounts/{id}/expenses` for an account that has no expenses in the requested date window
+- **THEN** the system returns HTTP 200 with an empty content list
+
+#### Scenario: Account not found
+- **WHEN** a caller sends `GET /accounts/{id}/expenses` with an account ID that does not exist
+- **THEN** the system returns HTTP 404
+
+#### Scenario: category and subcategory both provided
+- **WHEN** a caller sends `GET /accounts/{id}/expenses` with both `category` and `subcategory` query params
+- **THEN** the system returns HTTP 400
+
+#### Scenario: Cursor pagination works
+- **WHEN** a caller sends `GET /accounts/{id}/expenses` with a `cursor` from a previous response
+- **THEN** the system returns the next page of results relative to that cursor
+
+#### Scenario: Date window defaults apply
+- **WHEN** no `start_date` or `end_date` are provided
+- **THEN** the system defaults to the previous calendar month, consistent with `GET /expenses`

--- a/openspec/changes/add-account-expenses-route/tasks.md
+++ b/openspec/changes/add-account-expenses-route/tasks.md
@@ -1,0 +1,18 @@
+## 1. Controller
+
+- [x] 1.1 Inject `ExpenseService` into `AccountController`
+- [x] 1.2 Add `GET /accounts/{id}/expenses` endpoint — resolve account via `AccountService.getById(id)`, then delegate to `ExpenseService.listByUser` with the account's `createdBy` as `userId` and the path `id` as `accountId`
+
+## 2. Unit Tests
+
+- [x] 2.1 Add `AccountControllerTest` case: account exists with expenses → 200 with paginated body
+- [x] 2.2 Add `AccountControllerTest` case: account not found → 404
+- [x] 2.3 Add `AccountControllerTest` case: category + subcategory both provided → 400 (delegated to service)
+
+## 3. Integration Tests
+
+- [x] 3.1 Add `AccountControllerIT` test: existing account with expenses returns 200 with correct items
+- [x] 3.2 Add `AccountControllerIT` test: existing account with no expenses returns 200 with empty list
+- [x] 3.3 Add `AccountControllerIT` test: unknown account ID returns 404
+- [x] 3.4 Add `AccountControllerIT` test: category filter scopes results correctly
+- [x] 3.5 Add `AccountControllerIT` test: cursor pagination works across pages

--- a/src/integrationTest/java/com/novelosoftware/expenses/controllers/AccountControllerIT.java
+++ b/src/integrationTest/java/com/novelosoftware/expenses/controllers/AccountControllerIT.java
@@ -272,6 +272,23 @@ class AccountControllerIT extends BaseIT {
     }
 
     @Test
+    void listExpenses_onlyReturnsExpensesForSpecifiedAccount() throws Exception {
+        long accountA = createAccount("Card A", "user-ae");
+        long accountB = createAccount("Card B", "user-ae");
+        createExpenseOnDate(accountA, "user-ae", "2026-05-10");
+        createExpenseOnDate(accountA, "user-ae", "2026-05-15");
+        createExpenseOnDate(accountB, "user-ae", "2026-05-20"); // should NOT appear
+
+        mockMvc.perform(get("/accounts/{id}/expenses", accountA)
+                .param("start_date", "2026-05-01")
+                .param("end_date", "2026-05-31"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content.length()").value(2))
+            .andExpect(jsonPath("$.content[0].accountId").value(accountA))
+            .andExpect(jsonPath("$.content[1].accountId").value(accountA));
+    }
+
+    @Test
     void listExpenses_accountWithNoExpenses_returns200WithEmptyList() throws Exception {
         long accountId = createAccount("Empty Card", "user-ae");
 

--- a/src/integrationTest/java/com/novelosoftware/expenses/controllers/AccountControllerIT.java
+++ b/src/integrationTest/java/com/novelosoftware/expenses/controllers/AccountControllerIT.java
@@ -1,8 +1,11 @@
 package com.novelosoftware.expenses.controllers;
 
 import com.novelosoftware.expenses.BaseIT;
+import com.novelosoftware.expenses.util.ExpenseCursor;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+
+import java.time.LocalDate;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -246,6 +249,89 @@ class AccountControllerIT extends BaseIT {
         mockMvc.perform(delete("/accounts/{id}", accountId))
             .andExpect(status().isPreconditionFailed())
             .andExpect(jsonPath("$.code").value("PRECONDITION_FAILED"));
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /accounts/{id}/expenses
+    // -------------------------------------------------------------------------
+
+    @Test
+    void listExpenses_accountWithExpenses_returns200WithItems() throws Exception {
+        long accountId = createAccount("My Card", "user-ae");
+        createExpenseOnDate(accountId, "user-ae", "2026-05-10");
+        createExpenseOnDate(accountId, "user-ae", "2026-05-20");
+
+        mockMvc.perform(get("/accounts/{id}/expenses", accountId)
+                .param("start_date", "2026-05-01")
+                .param("end_date", "2026-05-31"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content.length()").value(2))
+            .andExpect(jsonPath("$.content[0].accountId").value(accountId))
+            .andExpect(jsonPath("$.content[0].expenseDate").value("2026-05-20")) // newest first
+            .andExpect(jsonPath("$.content[1].expenseDate").value("2026-05-10"));
+    }
+
+    @Test
+    void listExpenses_accountWithNoExpenses_returns200WithEmptyList() throws Exception {
+        long accountId = createAccount("Empty Card", "user-ae");
+
+        mockMvc.perform(get("/accounts/{id}/expenses", accountId)
+                .param("start_date", "2026-05-01")
+                .param("end_date", "2026-05-31"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").isEmpty());
+    }
+
+    @Test
+    void listExpenses_unknownAccountId_returns404() throws Exception {
+        mockMvc.perform(get("/accounts/{id}/expenses", 999999)
+                .param("start_date", "2026-05-01")
+                .param("end_date", "2026-05-31"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void listExpenses_categoryFilter_scopesResults() throws Exception {
+        long accountId = createAccount("Filter Card", "user-ae");
+        createExpenseWithSubcategoryOnDate(accountId, "user-ae", "2026-05-10", "RESTAURANT");
+        createExpenseWithSubcategoryOnDate(accountId, "user-ae", "2026-05-15", "GROCERIES");
+
+        mockMvc.perform(get("/accounts/{id}/expenses", accountId)
+                .param("start_date", "2026-05-01")
+                .param("end_date", "2026-05-31")
+                .param("subcategory", "GROCERIES"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content.length()").value(1))
+            .andExpect(jsonPath("$.content[0].subCategory").value("GROCERIES"));
+    }
+
+    @Test
+    void listExpenses_cursorPagination_secondPageFollowsFirst() throws Exception {
+        long accountId = createAccount("Paged Card", "user-ae");
+        createExpenseOnDate(accountId, "user-ae", "2026-05-10");
+        createExpenseOnDate(accountId, "user-ae", "2026-05-15");
+        createExpenseOnDate(accountId, "user-ae", "2026-05-20");
+
+        String firstPageJson = mockMvc.perform(get("/accounts/{id}/expenses", accountId)
+                .param("start_date", "2026-05-01")
+                .param("end_date", "2026-05-31")
+                .param("limit", "2"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content.length()").value(2))
+            .andExpect(jsonPath("$.nextCursor").isString())
+            .andReturn().getResponse().getContentAsString();
+
+        String nextCursor = objectMapper.readTree(firstPageJson).path("nextCursor").asText();
+
+        mockMvc.perform(get("/accounts/{id}/expenses", accountId)
+                .param("start_date", "2026-05-01")
+                .param("end_date", "2026-05-31")
+                .param("limit", "2")
+                .param("cursor", nextCursor))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content.length()").value(1))
+            .andExpect(jsonPath("$.nextCursor").doesNotExist());
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/com/novelosoftware/expenses/controllers/AccountController.java
+++ b/src/main/java/com/novelosoftware/expenses/controllers/AccountController.java
@@ -2,8 +2,12 @@ package com.novelosoftware.expenses.controllers;
 
 import com.novelosoftware.expenses.dto.*;
 import com.novelosoftware.expenses.services.AccountService;
+import com.novelosoftware.expenses.services.ExpenseService;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 /**
  * REST controller for account operations.
@@ -14,12 +18,15 @@ import org.springframework.web.bind.annotation.*;
 public class AccountController {
 
     private final AccountService service;
+    private final ExpenseService expenseService;
 
     /**
-     * @param service the service handling account business logic
+     * @param service        the service handling account business logic
+     * @param expenseService the service handling expense queries
      */
-    public AccountController(AccountService service) {
+    public AccountController(AccountService service, ExpenseService expenseService) {
         this.service = service;
+        this.expenseService = expenseService;
     }
 
     /**
@@ -82,5 +89,34 @@ public class AccountController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Long id) {
         service.delete(id);
+    }
+
+    /**
+     * Lists expenses for a specific account with cursor pagination and optional filters.
+     * The owner (user_id) is resolved from the account, so callers do not need to supply it.
+     *
+     * @param id          the account ID (path)
+     * @param startDate   optional start of date window; defaults to first day of last month
+     * @param endDate     optional end of date window; defaults to last day of last month
+     * @param limit       optional page size (1–100); defaults to 20
+     * @param cursor      optional opaque cursor from a previous response's {@code nextCursor}
+     * @param category    optional category filter; mutually exclusive with subcategory
+     * @param subcategory optional subcategory filter; mutually exclusive with category
+     * @return a page of expenses and an optional next-page cursor
+     */
+    @GetMapping("/{id}/expenses")
+    public CursorPageResponse<Expense> listExpenses(
+            @PathVariable Long id,
+            @RequestParam(value = "start_date", required = false)
+                @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(value = "end_date", required = false)
+                @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @RequestParam(value = "limit", required = false) Integer limit,
+            @RequestParam(value = "cursor", required = false) String cursor,
+            @RequestParam(value = "category", required = false) String category,
+            @RequestParam(value = "subcategory", required = false) String subcategory) {
+
+        String userId = service.getById(id).createdBy();
+        return expenseService.listByUser(userId, startDate, endDate, limit, cursor, category, subcategory, id);
     }
 }

--- a/src/test/java/com/novelosoftware/expenses/controllers/AccountControllerTest.java
+++ b/src/test/java/com/novelosoftware/expenses/controllers/AccountControllerTest.java
@@ -1,11 +1,10 @@
 package com.novelosoftware.expenses.controllers;
 
-import com.novelosoftware.expenses.dto.Account;
-import com.novelosoftware.expenses.dto.AccountType;
-import com.novelosoftware.expenses.dto.CreateAccountResponse;
-import com.novelosoftware.expenses.dto.PageResponse;
+import com.novelosoftware.expenses.dto.*;
 import com.novelosoftware.expenses.exceptions.GlobalExceptionHandler;
+import com.novelosoftware.expenses.exceptions.ExpenseServiceExceptions;
 import com.novelosoftware.expenses.services.AccountService;
+import com.novelosoftware.expenses.services.ExpenseService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -15,10 +14,12 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -37,6 +38,9 @@ class AccountControllerTest {
 
     @MockitoBean
     private AccountService service;
+
+    @MockitoBean
+    private ExpenseService expenseService;
 
     @Test
     void getByUser_returnsPaginatedAccounts() throws Exception {
@@ -130,6 +134,50 @@ class AccountControllerTest {
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
             .andExpect(jsonPath("$.message").value("Invalid value 'SAVINGS'. Accepted values: DEBIT, CREDIT"));
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /accounts/{id}/expenses
+    // -------------------------------------------------------------------------
+
+    @Test
+    void listExpenses_accountExists_returns200WithPage() throws Exception {
+        Expense expense = new Expense(10L, LocalDate.of(2026, 5, 10), 1L,
+            new BigDecimal("42.50"), "Tacos", SubCategory.RESTAURANT, "user-1");
+        CursorPageResponse<Expense> page = new CursorPageResponse<>(List.of(expense), null, 20);
+
+        when(service.getById(1L)).thenReturn(anAccount(1L));
+        when(expenseService.listByUser(eq("user-1"), isNull(), isNull(), isNull(), isNull(),
+            isNull(), isNull(), eq(1L))).thenReturn(page);
+
+        mockMvc.perform(get("/accounts/1/expenses"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content.length()").value(1))
+            .andExpect(jsonPath("$.content[0].expenseId").value(10));
+    }
+
+    @Test
+    void listExpenses_accountNotFound_returns404() throws Exception {
+        when(service.getById(99L)).thenThrow(createAccountNotFoundException(99L));
+
+        mockMvc.perform(get("/accounts/99/expenses"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    void listExpenses_categoryAndSubcategoryBothProvided_returns400() throws Exception {
+        when(service.getById(1L)).thenReturn(anAccount(1L));
+        when(expenseService.listByUser(any(), any(), any(), any(), any(),
+            eq("Food"), eq("Groceries"), eq(1L)))
+            .thenThrow(ExpenseServiceExceptions.createValidationException(
+                "category and subcategory are mutually exclusive; provide at most one"));
+
+        mockMvc.perform(get("/accounts/1/expenses")
+                .param("category", "Food")
+                .param("subcategory", "Groceries"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("BAD_REQUEST"));
     }
 
     private Account anAccount(Long id) {


### PR DESCRIPTION
## Summary

- Adds `GET /accounts/{id}/expenses` as a more ergonomic shortcut for listing expenses on a specific account
- The account owner (`user_id`) is resolved internally from the account record — callers don't need to supply it
- Full parity with `GET /expenses`: cursor pagination, date window, limit, category/subcategory filters all supported

## What changed

**Controller** (`AccountController`): injected `ExpenseService` and added `GET /{id}/expenses`. Resolves the account via `AccountService.getById(id)` (returns 404 if absent), extracts `createdBy` as the userId, then delegates to `ExpenseService.listByUser` with the path `id` pre-filled as `accountId`.

No new service or repository logic — this is purely a routing convenience on top of existing code.

## Test plan

- [x] `AccountControllerTest` — account found returns 200 with page, account not found returns 404, category+subcategory returns 400 (unit, MockMvc)
- [x] `AccountControllerIT` — account with expenses returns correct items (newest first), empty account returns empty list, unknown ID returns 404, category filter scopes results, cursor pagination works across pages (integration, Testcontainers)
- [x] All 239 tests passing (unit + integration)

## Reviewer notes

`GET /expenses?account_id=` still works and is not deprecated. This route is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)