### PR TITLE
Add production profile with SQL init config

### DIFF
--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -1,0 +1,4 @@
+spring.sql.init.mode=always
+spring.sql.init.platform=postgresql
+spring.sql.init.schema-locations=classpath:/db/schema.sql
+spring.sql.init.continue-on-error=false


### PR DESCRIPTION
## Summary

- Adds `application-production.properties` with SQL schema initialization config
- Ensures `schema.sql` runs on startup when deployed to Railway with the `production` profile
- Safe to run on every startup since the schema uses `CREATE TABLE IF NOT EXISTS`

## Test plan

- [ ] Deploy to Railway and confirm tables are created on first startup
- [ ] Redeploy and confirm existing data is not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)