### PR TITLE
Add logging authentication entry point to surface JWT failures

### DIFF
--- a/src/main/java/com/novelosoftware/expenses/security/SecurityConfig.java
+++ b/src/main/java/com/novelosoftware/expenses/security/SecurityConfig.java
@@ -1,5 +1,9 @@
 package com.novelosoftware.expenses.security;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -7,22 +11,39 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+
+import java.io.IOException;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
 public class SecurityConfig {
 
+    private static final Logger log = LoggerFactory.getLogger(SecurityConfig.class);
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
                 .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
-                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .jwt(Customizer.withDefaults())
+                        .authenticationEntryPoint(loggingEntryPoint()))
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .csrf(csrf -> csrf.disable())
                 .build();
+    }
+
+    private AuthenticationEntryPoint loggingEntryPoint() {
+        return (HttpServletRequest request, HttpServletResponse response, AuthenticationException ex) -> {
+            log.error("Authentication failed: {}", ex.getMessage(), ex);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"code\":\"UNAUTHORIZED\",\"message\":\"Authentication failed\"}");
+        };
     }
 }


### PR DESCRIPTION
## Summary

- Replaces the default silent `Bearer` 401 with a custom `AuthenticationEntryPoint` wired into the OAuth2 resource server config
- Logs the full `AuthenticationException` (including cause) at ERROR level so JWT failures (issuer mismatch, expired token, invalid signature) are visible in Railway logs
- Returns a generic `{"code":"UNAUTHORIZED","message":"Authentication failed"}` body — no internal details leaked to callers

## Why

The bare `WWW-Authenticate: Bearer` response with no body made it impossible to diagnose auth failures from logs. The root cause (Auth0 issuer trailing-slash mismatch) was invisible until logs were manually inspected. Going forward any JWT validation error will appear in logs immediately.

## Security note

The response body is intentionally generic. Full exception detail is server-side only to avoid leaking issuer URLs, token structure hints, or other information useful for probing the API.

## Reviewer notes

- No changes to auth logic or scope enforcement — only observability and response body
- `IOException` from `getWriter().write(...)` propagates naturally (no swallowing)