### PR TITLE
Accept at+jwt token type issued by Auth0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	integrationTestImplementation 'org.springframework.boot:spring-boot-testcontainers'

--- a/src/main/java/com/novelosoftware/expenses/security/SecurityConfig.java
+++ b/src/main/java/com/novelosoftware/expenses/security/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
@@ -62,13 +63,15 @@ public class SecurityConfig {
 
         @Bean
         public JwtDecoder jwtDecoder() {
-            return NimbusJwtDecoder.withIssuerLocation(issuerUri)
+            NimbusJwtDecoder decoder = NimbusJwtDecoder.withIssuerLocation(issuerUri)
                     .jwtProcessorCustomizer(p -> p.setJWSTypeVerifier(
                             new DefaultJOSEObjectTypeVerifier<>(
                                     new JOSEObjectType("at+jwt"),
                                     JOSEObjectType.JWT,
                                     null)))
                     .build();
+            decoder.setJwtValidator(JwtValidators.createDefaultWithIssuer(issuerUri));
+            return decoder;
         }
     }
 }

--- a/src/main/java/com/novelosoftware/expenses/security/SecurityConfig.java
+++ b/src/main/java/com/novelosoftware/expenses/security/SecurityConfig.java
@@ -1,9 +1,13 @@
 package com.novelosoftware.expenses.security;
 
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -12,6 +16,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -45,5 +51,24 @@ public class SecurityConfig {
             response.setContentType("application/json");
             response.getWriter().write("{\"code\":\"UNAUTHORIZED\",\"message\":\"Authentication failed\"}");
         };
+    }
+
+    @Configuration
+    @ConditionalOnExpression("!'${spring.security.oauth2.resourceserver.jwt.issuer-uri:}'.isEmpty()")
+    static class IssuerUriJwtDecoderConfig {
+
+        @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
+        private String issuerUri;
+
+        @Bean
+        public JwtDecoder jwtDecoder() {
+            return NimbusJwtDecoder.withIssuerLocation(issuerUri)
+                    .jwtProcessorCustomizer(p -> p.setJWSTypeVerifier(
+                            new DefaultJOSEObjectTypeVerifier<>(
+                                    new JOSEObjectType("at+jwt"),
+                                    JOSEObjectType.JWT,
+                                    null)))
+                    .build();
+        }
     }
 }

--- a/src/test/java/com/novelosoftware/expenses/security/IssuerUriJwtDecoderConfigTest.java
+++ b/src/test/java/com/novelosoftware/expenses/security/IssuerUriJwtDecoderConfigTest.java
@@ -1,0 +1,123 @@
+package com.novelosoftware.expenses.security;
+
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidationException;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+import java.security.KeyFactory;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class IssuerUriJwtDecoderConfigTest {
+
+    private static final String ISSUER = "https://dev-pvjriuvkhfjjreft.us.auth0.com/";
+    private static RSAPrivateKey privateKey;
+    private static JwtDecoder decoder;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        privateKey = loadPrivateKey();
+        RSAPublicKey publicKey = loadPublicKey();
+
+        // Mirror the exact customizations applied in IssuerUriJwtDecoderConfig
+        NimbusJwtDecoder nimbusDecoder = NimbusJwtDecoder.withPublicKey(publicKey)
+                .jwtProcessorCustomizer(p -> p.setJWSTypeVerifier(
+                        new DefaultJOSEObjectTypeVerifier<>(
+                                new JOSEObjectType("at+jwt"),
+                                JOSEObjectType.JWT,
+                                null)))
+                .build();
+        nimbusDecoder.setJwtValidator(JwtValidators.createDefaultWithIssuer(ISSUER));
+        decoder = nimbusDecoder;
+    }
+
+    @Test
+    void atJwtTyp_validIssuer_isAccepted() {
+        String token = buildToken(new JWSHeader.Builder(JWSAlgorithm.RS256)
+                .type(new JOSEObjectType("at+jwt"))
+                .build(), ISSUER, validExpiry());
+
+        assertThat(decoder.decode(token).getIssuer().toString()).isEqualTo(ISSUER);
+    }
+
+    @Test
+    void plainJwtTyp_validIssuer_isAccepted() {
+        String token = buildToken(new JWSHeader(JWSAlgorithm.RS256), ISSUER, validExpiry());
+
+        assertThat(decoder.decode(token).getIssuer().toString()).isEqualTo(ISSUER);
+    }
+
+    @Test
+    void wrongIssuer_isRejected() {
+        String token = buildToken(new JWSHeader.Builder(JWSAlgorithm.RS256)
+                .type(new JOSEObjectType("at+jwt"))
+                .build(), "https://evil.example.com/", validExpiry());
+
+        assertThatThrownBy(() -> decoder.decode(token))
+                .isInstanceOf(JwtValidationException.class)
+                .hasMessageContaining("iss");
+    }
+
+    // --- helpers ---
+
+    private static Date validExpiry() {
+        return new Date(System.currentTimeMillis() + 3_600_000);
+    }
+
+    private static String buildToken(JWSHeader header, String issuer, Date expiry) {
+        try {
+            JWSSigner signer = new RSASSASigner(privateKey);
+            JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                    .subject("test-user")
+                    .issuer(issuer)
+                    .expirationTime(expiry)
+                    .claim("scope", "read:accounts")
+                    .build();
+            SignedJWT jwt = new SignedJWT(header, claims);
+            jwt.sign(signer);
+            return jwt.serialize();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static RSAPrivateKey loadPrivateKey() throws Exception {
+        byte[] bytes = IssuerUriJwtDecoderConfigTest.class
+                .getResourceAsStream("/local/test-rsa-private.pem").readAllBytes();
+        String pem = new String(bytes)
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replaceAll("\\s", "");
+        return (RSAPrivateKey) KeyFactory.getInstance("RSA")
+                .generatePrivate(new PKCS8EncodedKeySpec(Base64.getDecoder().decode(pem)));
+    }
+
+    private static RSAPublicKey loadPublicKey() throws Exception {
+        byte[] bytes = IssuerUriJwtDecoderConfigTest.class
+                .getResourceAsStream("/local/test-rsa-public.pem").readAllBytes();
+        String pem = new String(bytes)
+                .replace("-----BEGIN PUBLIC KEY-----", "")
+                .replace("-----END PUBLIC KEY-----", "")
+                .replaceAll("\\s", "");
+        return (RSAPublicKey) KeyFactory.getInstance("RSA")
+                .generatePublic(new X509EncodedKeySpec(Base64.getDecoder().decode(pem)));
+    }
+}

--- a/src/test/java/com/novelosoftware/expenses/security/IssuerUriJwtDecoderConfigTest.java
+++ b/src/test/java/com/novelosoftware/expenses/security/IssuerUriJwtDecoderConfigTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class IssuerUriJwtDecoderConfigTest {
 
-    private static final String ISSUER = "https://dev-pvjriuvkhfjjreft.us.auth0.com/";
+    private static final String ISSUER = "https://test-issuer.example.com/";
     private static RSAPrivateKey privateKey;
     private static JwtDecoder decoder;
 

--- a/src/test/java/com/novelosoftware/expenses/security/IssuerUriJwtDecoderConfigTest.java
+++ b/src/test/java/com/novelosoftware/expenses/security/IssuerUriJwtDecoderConfigTest.java
@@ -5,73 +5,95 @@ import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.crypto.RSASSASigner;
-import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtValidationException;
-import org.springframework.security.oauth2.jwt.JwtValidators;
-import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 
 import java.security.KeyFactory;
 import java.security.interfaces.RSAPrivateKey;
-import java.security.interfaces.RSAPublicKey;
 import java.security.spec.PKCS8EncodedKeySpec;
-import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@SpringBootTest(classes = SecurityConfig.IssuerUriJwtDecoderConfig.class,
+        properties = "spring.main.web-application-type=none")
 class IssuerUriJwtDecoderConfigTest {
 
-    private static final String ISSUER = "https://test-issuer.example.com/";
-    private static RSAPrivateKey privateKey;
-    private static JwtDecoder decoder;
+    static MockWebServer mockOidc;
+    static String issuer;
+    static RSAPrivateKey privateKey;
 
     @BeforeAll
     static void setUp() throws Exception {
         privateKey = loadPrivateKey();
-        RSAPublicKey publicKey = loadPublicKey();
 
-        // Mirror the exact customizations applied in IssuerUriJwtDecoderConfig
-        NimbusJwtDecoder nimbusDecoder = NimbusJwtDecoder.withPublicKey(publicKey)
-                .jwtProcessorCustomizer(p -> p.setJWSTypeVerifier(
-                        new DefaultJOSEObjectTypeVerifier<>(
-                                new JOSEObjectType("at+jwt"),
-                                JOSEObjectType.JWT,
-                                null)))
-                .build();
-        nimbusDecoder.setJwtValidator(JwtValidators.createDefaultWithIssuer(ISSUER));
-        decoder = nimbusDecoder;
+        mockOidc = new MockWebServer();
+        mockOidc.start();
+        issuer = "http://localhost:" + mockOidc.getPort();
+
+        // Spring fetches /.well-known/openid-configuration and then the jwks_uri on startup.
+        // Queue two responses so the decoder initialises correctly.
+        String jwksUri = issuer + "/jwks";
+        mockOidc.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""
+                        {"issuer":"%s","jwks_uri":"%s"}
+                        """.formatted(issuer, jwksUri)));
+        mockOidc.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody(jwksResponse()));
     }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        mockOidc.shutdown();
+    }
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry registry) {
+        registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri",
+                () -> "http://localhost:" + mockOidc.getPort());
+    }
+
+    @Autowired
+    JwtDecoder jwtDecoder;
 
     @Test
     void atJwtTyp_validIssuer_isAccepted() {
-        String token = buildToken(new JWSHeader.Builder(JWSAlgorithm.RS256)
-                .type(new JOSEObjectType("at+jwt"))
-                .build(), ISSUER, validExpiry());
+        String token = buildToken(
+                new JWSHeader.Builder(JWSAlgorithm.RS256).type(new JOSEObjectType("at+jwt")).build(),
+                issuer, validExpiry());
 
-        assertThat(decoder.decode(token).getIssuer().toString()).isEqualTo(ISSUER);
+        assertThat(jwtDecoder.decode(token).getIssuer().toString()).isEqualTo(issuer);
     }
 
     @Test
     void plainJwtTyp_validIssuer_isAccepted() {
-        String token = buildToken(new JWSHeader(JWSAlgorithm.RS256), ISSUER, validExpiry());
+        String token = buildToken(new JWSHeader(JWSAlgorithm.RS256), issuer, validExpiry());
 
-        assertThat(decoder.decode(token).getIssuer().toString()).isEqualTo(ISSUER);
+        assertThat(jwtDecoder.decode(token).getIssuer().toString()).isEqualTo(issuer);
     }
 
     @Test
     void wrongIssuer_isRejected() {
-        String token = buildToken(new JWSHeader.Builder(JWSAlgorithm.RS256)
-                .type(new JOSEObjectType("at+jwt"))
-                .build(), "https://evil.example.com/", validExpiry());
+        String token = buildToken(
+                new JWSHeader.Builder(JWSAlgorithm.RS256).type(new JOSEObjectType("at+jwt")).build(),
+                "https://evil.example.com/", validExpiry());
 
-        assertThatThrownBy(() -> decoder.decode(token))
+        assertThatThrownBy(() -> jwtDecoder.decode(token))
                 .isInstanceOf(JwtValidationException.class)
                 .hasMessageContaining("iss");
     }
@@ -82,12 +104,12 @@ class IssuerUriJwtDecoderConfigTest {
         return new Date(System.currentTimeMillis() + 3_600_000);
     }
 
-    private static String buildToken(JWSHeader header, String issuer, Date expiry) {
+    private static String buildToken(JWSHeader header, String tokenIssuer, Date expiry) {
         try {
             JWSSigner signer = new RSASSASigner(privateKey);
             JWTClaimsSet claims = new JWTClaimsSet.Builder()
                     .subject("test-user")
-                    .issuer(issuer)
+                    .issuer(tokenIssuer)
                     .expirationTime(expiry)
                     .claim("scope", "read:accounts")
                     .build();
@@ -110,14 +132,26 @@ class IssuerUriJwtDecoderConfigTest {
                 .generatePrivate(new PKCS8EncodedKeySpec(Base64.getDecoder().decode(pem)));
     }
 
-    private static RSAPublicKey loadPublicKey() throws Exception {
+    // Minimal JWKS containing the test RSA public key
+    private static String jwksResponse() throws Exception {
         byte[] bytes = IssuerUriJwtDecoderConfigTest.class
                 .getResourceAsStream("/local/test-rsa-public.pem").readAllBytes();
         String pem = new String(bytes)
                 .replace("-----BEGIN PUBLIC KEY-----", "")
                 .replace("-----END PUBLIC KEY-----", "")
                 .replaceAll("\\s", "");
-        return (RSAPublicKey) KeyFactory.getInstance("RSA")
-                .generatePublic(new X509EncodedKeySpec(Base64.getDecoder().decode(pem)));
+
+        java.security.interfaces.RSAPublicKey pub = (java.security.interfaces.RSAPublicKey)
+                KeyFactory.getInstance("RSA").generatePublic(
+                        new java.security.spec.X509EncodedKeySpec(Base64.getDecoder().decode(pem)));
+
+        String n = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(pub.getModulus().toByteArray());
+        String e = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(pub.getPublicExponent().toByteArray());
+
+        return """
+                {"keys":[{"kty":"RSA","use":"sig","alg":"RS256","n":"%s","e":"%s"}]}
+                """.formatted(n, e);
     }
 }


### PR DESCRIPTION
## Summary

- Configures a custom `JwtDecoder` that accepts `typ: at+jwt` (RFC 9068) in addition to `typ: JWT`
- Auth0 access tokens use `at+jwt` by default; Spring Security's Nimbus decoder rejects this type out of the box
- The custom decoder is only activated when `issuer-uri` is configured (production); tests and local dev using `public-key-location` continue to use Spring Boot's auto-configured decoder

## Why

After fixing the issuer URI trailing slash, the next error in Railway logs was:
```
JOSE header typ (type) at+jwt not allowed
```

## Reviewer notes

- `@ConditionalOnExpression` on a nested static config class is used because the `issuer-uri` property exists in `application.properties` with an empty default (`${OAUTH_ISSUER_URI:}`), so `@ConditionalOnProperty` incorrectly matched even in tests
- All 90 integration tests pass