### PR TITLE
Add transactionAmount field with criteria search

### DIFF
--- a/openspec/changes/add-transaction-amount/.openspec.yaml
+++ b/openspec/changes/add-transaction-amount/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-17

--- a/openspec/changes/add-transaction-amount/design.md
+++ b/openspec/changes/add-transaction-amount/design.md
@@ -1,0 +1,45 @@
+## Context
+
+Expenses are stored in a single Postgres `expenses` table accessed through hand-written SQL on `JdbcTemplate` (no JPA). The list endpoint `GET /expenses` runs a criteria search in `ExpenseRepository.findByFiltersCursor` that mandates `created_by` + a date range (bounded by `idx_expenses_user_date`) and applies optional `category`/`subcategory`/`account_id` predicates on top, with keyset (cursor) pagination ordered by `expense_date DESC, expense_id DESC`.
+
+We need to record the original transaction total on each expense line so that lines produced by splitting a single transaction can later be found together. The user has explicitly deferred adding a database index for the new column.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a nullable `transaction_amount` column to `expenses` and surface it through the entity, DTO, and mapper.
+- Persist it on create, bulk-create, and update.
+- Add an exact-match `transaction_amount` filter to the existing criteria search, reusing the current cursor pagination.
+
+**Non-Goals:**
+- No index on `transaction_amount` in this change (the user will decide later).
+- No automatic split workflow / endpoint — callers set `transactionAmount` themselves on each line.
+- The system never derives `transactionAmount` from `amount` changes or split logic; the only "computed" behavior is defaulting a null request value to the line's `amount`.
+- No range or fuzzy matching on `transaction_amount` (exact equality only).
+- No backfill of `transaction_amount` for existing rows (they remain `null`).
+
+## Decisions
+
+- **Nullable column, defaulted to `amount` only at creation.** `transaction_amount NUMERIC(15,2)` is nullable in the schema (so existing rows and the column add stay simple). On the **create** and **bulk-create** paths the service resolves a null request value to the line's `amount` before persisting, so a freshly created un-split expense naturally has `transactionAmount == amount`. The default is applied in `ExpenseService`, not in SQL, so the resolved value is reflected in the response. Alternative considered: a SQL `DEFAULT`/`COALESCE` — rejected because it wouldn't round-trip the resolved value into the returned DTO and would split the rule across layers.
+- **Update is partial for `amount` and `transactionAmount`.** `PUT /expenses/{id}` already fetches the existing entity (for ownership checks). The update path SHALL merge nulls from the stored row: a null `amount` keeps the stored `amount` (no validation error), and a null `transactionAmount` keeps the stored `transactionAmount` (it is NOT re-defaulted to `amount`). The create-time "null → amount" default does not run on update. Rationale: the user wants update to change a field only when explicitly provided. This requires relaxing the current `expenseWriteValidations`, which rejects a null `amount` — on the update path, `amount` (and `transactionAmount`) become optional and are back-filled from the persisted entity before the SQL `UPDATE`.
+- **Default is never derived from splits.** The service only substitutes `amount` for a null `transactionAmount` at creation; it never recomputes it from `amount` edits or split operations. Callers that split a transaction are responsible for sending the original total on each line.
+- **Additive migration in `schema.sql`.** Follow the existing pattern (`ALTER TABLE ... ADD COLUMN IF NOT EXISTS`) used for `accounts.period_start`. No index statement, per the user's instruction.
+- **Exact-equality filter threaded through the existing method.** Add a `BigDecimal transactionAmount` parameter to `findByFiltersCursor` and append `AND transaction_amount = ?` when non-null — identical in shape to the existing optional predicates. Rationale: reuse the proven criteria + keyset path rather than a parallel query. Alternative considered: a dedicated finder method — rejected as duplicative.
+- **Filter not encoded in the cursor.** Consistent with `category`/`subcategory`/`accountId`, the caller resupplies `transaction_amount` on every page. The cursor stays `(expense_date, expense_id)`.
+- **Equality on NUMERIC.** Postgres compares `NUMERIC` by value, so `100.0 = 100.00`. Binding a `BigDecimal` avoids scale surprises; no special normalization needed.
+
+## Risks / Trade-offs
+
+- **Unindexed filter scans the date-bounded slice** → Acceptable: the mandatory `created_by` + date-range predicates already bound the scan via `idx_expenses_user_date`; `transaction_amount` is an in-memory filter over that slice. An index can be added later if needed.
+- **Float/scale mismatch from JSON clients** → Binding `BigDecimal` and relying on Postgres NUMERIC value-equality avoids `100.0` vs `100.00` mismatches.
+- **Column added to `RETURNING *` / `SELECT *` rows** → The `RowMapper` must read the new column; updating it and the insert/update column lists together keeps reads and writes consistent.
+
+## Migration Plan
+
+1. Apply the additive `ALTER TABLE expenses ADD COLUMN IF NOT EXISTS transaction_amount NUMERIC(15,2)` (idempotent, runs on startup with the rest of `schema.sql`).
+2. Deploy code that reads/writes the column and defaults null requests to `amount`. Existing rows keep `transaction_amount = null` (no backfill); newly written rows always carry a value; existing clients that don't send the field get `transactionAmount == amount` transparently.
+3. Rollback: revert the code; the nullable column can remain in place harmlessly (no drop required).
+
+## Open Questions
+
+- Whether to later add `idx_expenses_user_date_txamount` or a partial index once query volume on the filter is understood — deferred by the user.

--- a/openspec/changes/add-transaction-amount/proposal.md
+++ b/openspec/changes/add-transaction-amount/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+When a single real-world transaction is split into multiple expense lines (e.g. a $100 store purchase broken into Groceries $60 and Household $40), the original transaction total is lost — each split line only records its own `amount`. Users need to preserve the original transaction total on every split line so they can later locate all expenses that originated from the same transaction by searching against that total.
+
+## What Changes
+
+- Add a new optional `transactionAmount` field to the `Expense` DTO and a `transaction_amount` column to the `expenses` table. It records the amount of the original (pre-split) transaction. It is supplied by the API caller only — the system never derives it from `amount` changes or split logic. On **create/bulk-create**, when the caller omits it the system defaults it to the line's `amount`.
+- Persist `transactionAmount` on create, bulk-create, and update so split lines can carry the original total.
+- Make `PUT /expenses/{id}` partial for `amount` and `transactionAmount`: when either is omitted, the system preserves the currently stored value instead of returning a validation error. The create-time default-to-`amount` does not apply on update.
+- Add an optional `transaction_amount` query parameter to `GET /expenses` that filters results to expenses whose `transaction_amount` matches exactly. It reuses the existing criteria search (mandatory `created_by` + date range) and the existing cursor pagination — no new index is added in this change.
+
+## Capabilities
+
+### New Capabilities
+- `transaction-amount`: Recording the original transaction total on expense lines and searching expenses by that total via the existing cursor-paginated criteria search.
+
+### Modified Capabilities
+- `list-expenses-by-user`: The `GET /expenses` criteria search gains an additional optional `transaction_amount` filter alongside the existing required `created_by` + date range and optional category/subcategory/account filters.
+- `bulk-create-expenses`: Bulk-created expenses MAY carry a `transactionAmount` so a transaction split into many lines preserves the original total on each line.
+
+## Impact
+
+- **Schema**: `expenses` table gains a nullable `transaction_amount NUMERIC(15,2)` column (additive migration; no index in this change).
+- **DTO/Entity**: `Expense`, `ExpenseEntity`, and `ExpenseMapper` gain the new field.
+- **API**: `GET /expenses` accepts a new optional `transaction_amount` query parameter; create/bulk/update request bodies accept the field on the `Expense` value.
+- **Code**: `ExpenseRepository.findByFiltersCursor`, `ExpenseService.listForOwner`/`listByUser`/`listByAccount`, and `ExpenseController.list` thread the new optional filter through.
+- No breaking changes: the field and filter are optional; existing clients are unaffected.

--- a/openspec/changes/add-transaction-amount/specs/bulk-create-expenses/spec.md
+++ b/openspec/changes/add-transaction-amount/specs/bulk-create-expenses/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Bulk create preserves transaction amount on split lines
+Each expense object in a `POST /expenses/bulk` request MAY include an optional `transactionAmount`. When a single transaction is split into many lines submitted in one bulk request, every line MAY carry the same `transactionAmount` equal to the original transaction total while keeping its own distinct `amount`. The field is optional per item; when omitted on an item it SHALL be defaulted to that item's own `amount`. Persistence of `transactionAmount` SHALL be atomic with the rest of the bulk insert.
+
+#### Scenario: Bulk create splits one transaction into many lines
+- **WHEN** a `POST /expenses/bulk` request contains two expenses with `amount = 60.00` and `amount = 40.00`, both with `transactionAmount = 100.00`
+- **THEN** the system returns HTTP 201 and both created expenses have `transactionAmount = 100.00`
+
+#### Scenario: Mixed items — omitted transaction amount defaults to the item's amount
+- **WHEN** a `POST /expenses/bulk` request contains one expense with `amount = 60.00` and `transactionAmount = 100.00`, and one expense with `amount = 25.00` that omits `transactionAmount`
+- **THEN** the system returns HTTP 201, the first created expense has `transactionAmount = 100.00`, and the second has `transactionAmount = 25.00`

--- a/openspec/changes/add-transaction-amount/specs/list-expenses-by-user/spec.md
+++ b/openspec/changes/add-transaction-amount/specs/list-expenses-by-user/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: List expenses by user with date window
+The system SHALL expose a `GET /expenses` endpoint that returns a paginated list of expenses for a given user. `user_id` SHALL be a required query parameter. Once authentication is introduced, `user_id` will be inferred from the OAuth token and this parameter will be removed. `start_date` and `end_date` are both optional and independently defaulted:
+- Both absent: default to the previous calendar month (first day to last day).
+- Only `start_date` provided: `end_date` defaults to `start_date` plus 1 month.
+- Only `end_date` provided: `start_date` defaults to `end_date` minus 1 month.
+
+The date range from `start_date` to `end_date` SHALL NOT exceed 3 calendar months; requests exceeding this limit SHALL be rejected with HTTP 400. Optional filters `category`, `subcategory`, `accountId`, and `transaction_amount` MAY be supplied to narrow results; see the `expense-search-filters` and `transaction-amount` specs.
+
+#### Scenario: Missing user_id — rejected
+- **WHEN** a GET request is made to `/expenses` without a `user_id` parameter
+- **THEN** the system returns HTTP 400
+
+#### Scenario: Successful first-page request with explicit date range
+- **WHEN** a GET request is made to `/expenses?user_id=u1&start_date=2026-03-01&end_date=2026-05-31&limit=20`
+- **THEN** the system returns HTTP 200 with the first page of expenses in descending chronological order
+
+#### Scenario: Both date parameters absent — defaults to last calendar month
+- **WHEN** a GET request is made to `/expenses` without `start_date` or `end_date`
+- **THEN** the system returns HTTP 200 with expenses from the first to the last day of the previous calendar month
+
+#### Scenario: Only start_date provided — end_date defaults to start_date plus one month
+- **WHEN** a GET request is made with `start_date=2026-04-01` and no `end_date`
+- **THEN** the system returns HTTP 200 with expenses from `2026-04-01` to `2026-05-01`
+
+#### Scenario: Only end_date provided — start_date defaults to end_date minus one month
+- **WHEN** a GET request is made with `end_date=2026-05-01` and no `start_date`
+- **THEN** the system returns HTTP 200 with expenses from `2026-04-01` to `2026-05-01`
+
+#### Scenario: Date range exceeds 3 calendar months
+- **WHEN** a GET request is made with a date range spanning more than 3 calendar months
+- **THEN** the system returns HTTP 400
+
+#### Scenario: end_date is before start_date
+- **WHEN** a GET request is made with `end_date` earlier than `start_date`
+- **THEN** the system returns HTTP 400
+
+#### Scenario: Filter by transaction_amount within the date window
+- **WHEN** a GET request includes `transaction_amount=100.00` alongside the required `user_id` and date range
+- **THEN** the system returns HTTP 200 with only expenses whose `transaction_amount = 100.00` in the window

--- a/openspec/changes/add-transaction-amount/specs/transaction-amount/spec.md
+++ b/openspec/changes/add-transaction-amount/specs/transaction-amount/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Expense records an optional original transaction amount
-An expense SHALL carry an optional `transactionAmount` field (decimal) representing the amount of the original real-world transaction it was derived from. The value SHALL be supplied by the API caller only; the system SHALL NOT derive `transactionAmount` from `amount` changes or split logic. When the caller omits `transactionAmount` on a write, the system SHALL default it to that line's `amount` before persisting, and the resolved value SHALL be returned in the response. When a single transaction is split into multiple expense lines, each line SHALL be able to carry the same explicitly-supplied `transactionAmount` equal to the original transaction total, independent of each line's own `amount`. The field SHALL be accepted on create (`POST /expenses`), bulk create (`POST /expenses/bulk`), and update (`PUT /expenses/{id}`), and SHALL be returned on every expense representation.
+An expense SHALL carry an optional `transactionAmount` field (decimal) representing the amount of the original real-world transaction it was derived from. The value SHALL be supplied by the API caller only; the system SHALL NOT derive `transactionAmount` from `amount` changes or split logic. When the caller omits `transactionAmount` on **create** (`POST /expenses`) or **bulk create** (`POST /expenses/bulk`), the system SHALL default it to that line's `amount` before persisting, and the resolved value SHALL be returned in the response. This defaulting SHALL NOT apply on update — see the "Update preserves omitted amount and transaction amount" requirement, under which an omitted `transactionAmount` preserves the stored value. When a single transaction is split into multiple expense lines, each line SHALL be able to carry the same explicitly-supplied `transactionAmount` equal to the original transaction total, independent of each line's own `amount`. The field SHALL be accepted on create (`POST /expenses`), bulk create (`POST /expenses/bulk`), and update (`PUT /expenses/{id}`), and SHALL be returned on every expense representation.
 
 #### Scenario: Create an expense with a transaction amount
 - **WHEN** a `POST /expenses` request supplies `transactionAmount = 100.00` and `amount = 60.00`
@@ -33,6 +33,17 @@ On `PUT /expenses/{id}`, `amount` and `transactionAmount` SHALL be treated as pa
 #### Scenario: Update changes both amount and transaction amount explicitly
 - **WHEN** a `PUT /expenses/{id}` request supplies both `amount = 70.00` and `transactionAmount = 120.00`
 - **THEN** the system returns HTTP 200 and the updated expense has `amount = 70.00` and `transactionAmount = 120.00`
+
+### Requirement: Monetary values bounded to NUMERIC(15,2)
+Both `amount` and `transactionAmount` are persisted as `NUMERIC(15,2)`. On create, bulk create, and update the system SHALL reject a supplied value that does not fit this column — more than two fractional digits, or more than thirteen integer digits — with HTTP 400, rather than letting the database silently round the value or fail with a server error. A null value is not subject to this check (it is defaulted or preserved per the rules above).
+
+#### Scenario: More than two fractional digits rejected
+- **WHEN** a `POST /expenses` request supplies `transactionAmount = 100.123`
+- **THEN** the system returns HTTP 400 and no expense is created
+
+#### Scenario: More than thirteen integer digits rejected
+- **WHEN** a `POST /expenses` request supplies `amount = 12345678901234` (14 integer digits)
+- **THEN** the system returns HTTP 400 and no expense is created
 
 ### Requirement: Search expenses by transaction amount
 The `GET /expenses` criteria search SHALL accept an optional `transaction_amount` query parameter. When supplied, results SHALL be restricted to expenses whose `transaction_amount` equals the supplied value exactly. When absent, `transaction_amount` SHALL NOT constrain results. The filter reuses the existing mandatory `created_by` + date-range criteria search and the existing forward cursor pagination; the `transaction_amount` filter SHALL NOT be encoded in the cursor and the caller SHALL supply it on every page request. `transaction_amount` MAY be combined with the `category`, `subcategory`, and `accountId` filters. This change SHALL NOT add a database index for the new column.

--- a/openspec/changes/add-transaction-amount/specs/transaction-amount/spec.md
+++ b/openspec/changes/add-transaction-amount/specs/transaction-amount/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Expense records an optional original transaction amount
+An expense SHALL carry an optional `transactionAmount` field (decimal) representing the amount of the original real-world transaction it was derived from. The value SHALL be supplied by the API caller only; the system SHALL NOT derive `transactionAmount` from `amount` changes or split logic. When the caller omits `transactionAmount` on a write, the system SHALL default it to that line's `amount` before persisting, and the resolved value SHALL be returned in the response. When a single transaction is split into multiple expense lines, each line SHALL be able to carry the same explicitly-supplied `transactionAmount` equal to the original transaction total, independent of each line's own `amount`. The field SHALL be accepted on create (`POST /expenses`), bulk create (`POST /expenses/bulk`), and update (`PUT /expenses/{id}`), and SHALL be returned on every expense representation.
+
+#### Scenario: Create an expense with a transaction amount
+- **WHEN** a `POST /expenses` request supplies `transactionAmount = 100.00` and `amount = 60.00`
+- **THEN** the system returns HTTP 201 and the created expense has `transactionAmount = 100.00` and `amount = 60.00`
+
+#### Scenario: Create an expense without a transaction amount — defaults to amount
+- **WHEN** a `POST /expenses` request omits `transactionAmount` and supplies `amount = 60.00`
+- **THEN** the system returns HTTP 201 and the created expense has `transactionAmount = 60.00`
+
+#### Scenario: Split lines share the original transaction amount
+- **WHEN** two expenses are created with `amount = 60.00` and `amount = 40.00`, both with `transactionAmount = 100.00`
+- **THEN** both stored expenses have `transactionAmount = 100.00` while keeping their own distinct `amount`
+
+#### Scenario: Update sets the transaction amount
+- **WHEN** a `PUT /expenses/{id}` request supplies `transactionAmount = 100.00`
+- **THEN** the system returns HTTP 200 and the updated expense has `transactionAmount = 100.00`
+
+### Requirement: Update preserves omitted amount and transaction amount
+On `PUT /expenses/{id}`, `amount` and `transactionAmount` SHALL be treated as partial: when either is omitted (null) in the request, the system SHALL preserve the currently persisted value for that field rather than rejecting the request or recomputing a default. The create-time rule that defaults a null `transactionAmount` to `amount` SHALL apply only on creation, never on update. A null `amount` on update SHALL NOT produce a validation error.
+
+#### Scenario: Update with null amount preserves the existing amount
+- **WHEN** a `PUT /expenses/{id}` request omits `amount` for an expense currently stored with `amount = 60.00`
+- **THEN** the system returns HTTP 200 and the updated expense retains `amount = 60.00` (no HTTP 400)
+
+#### Scenario: Update with null transactionAmount preserves the existing transaction amount
+- **WHEN** a `PUT /expenses/{id}` request omits `transactionAmount` for an expense currently stored with `transactionAmount = 100.00`
+- **THEN** the system returns HTTP 200 and the updated expense retains `transactionAmount = 100.00` (it is not re-defaulted to the line's `amount`)
+
+#### Scenario: Update changes both amount and transaction amount explicitly
+- **WHEN** a `PUT /expenses/{id}` request supplies both `amount = 70.00` and `transactionAmount = 120.00`
+- **THEN** the system returns HTTP 200 and the updated expense has `amount = 70.00` and `transactionAmount = 120.00`
+
+### Requirement: Search expenses by transaction amount
+The `GET /expenses` criteria search SHALL accept an optional `transaction_amount` query parameter. When supplied, results SHALL be restricted to expenses whose `transaction_amount` equals the supplied value exactly. When absent, `transaction_amount` SHALL NOT constrain results. The filter reuses the existing mandatory `created_by` + date-range criteria search and the existing forward cursor pagination; the `transaction_amount` filter SHALL NOT be encoded in the cursor and the caller SHALL supply it on every page request. `transaction_amount` MAY be combined with the `category`, `subcategory`, and `accountId` filters. This change SHALL NOT add a database index for the new column.
+
+#### Scenario: Filter by transaction amount returns matching split lines
+- **WHEN** a `GET /expenses` request includes `transaction_amount=100.00` within the required user and date window
+- **THEN** the system returns HTTP 200 with only the expenses whose `transaction_amount = 100.00`, ordered by `expense_date DESC, expense_id DESC`
+
+#### Scenario: transaction_amount absent — not constrained
+- **WHEN** a `GET /expenses` request omits `transaction_amount`
+- **THEN** the result set is not narrowed by transaction amount
+
+#### Scenario: transaction_amount combined with accountId
+- **WHEN** a `GET /expenses` request includes both `transaction_amount=100.00` and `account_id=3`
+- **THEN** the system returns only expenses matching both predicates
+
+#### Scenario: transaction_amount pagination preserves the filter
+- **WHEN** a follow-up request includes a valid `cursor` and the same `transaction_amount` value as the first page
+- **THEN** the system returns the next page of expenses still filtered to that `transaction_amount`

--- a/openspec/changes/add-transaction-amount/tasks.md
+++ b/openspec/changes/add-transaction-amount/tasks.md
@@ -1,0 +1,35 @@
+## 1. Schema
+
+- [x] 1.1 In `src/main/resources/db/schema.sql`, add an additive migration `ALTER TABLE expenses ADD COLUMN IF NOT EXISTS transaction_amount NUMERIC(15, 2);` (no index, per design)
+
+## 2. Entity, DTO, and mapper
+
+- [x] 2.1 Add `BigDecimal transactionAmount` to `ExpenseEntity` (record component, builder field, builder setter, `toBuilder`, constructor)
+- [x] 2.2 Add `BigDecimal transactionAmount` to the `Expense` DTO (record component, builder field, builder setter, `toBuilder`, constructor)
+- [x] 2.3 Update `ExpenseMapper.toEntity` and `toDto` to map `transactionAmount` both directions
+- [x] 2.4 Update `ExpenseRepository.MAPPER` to read `transaction_amount` via `rs.getBigDecimal("transaction_amount")`
+
+## 3. Persistence (create / bulk / update)
+
+- [x] 3.1 In `ExpenseService` create and bulkCreate: when the request `transactionAmount` is null, substitute the line's `amount` before persisting (creation-only default; never derived from splits). Resolved value must flow into the response DTO
+- [x] 3.1a In `ExpenseService.update`: make `amount` and `transactionAmount` partial. Stop rejecting a null `amount` for the update path, and after loading the existing (owned) entity, back-fill null `amount`/`transactionAmount` from the persisted row before the SQL `UPDATE` (do NOT re-default `transactionAmount` to `amount` on update). Keep the other write validations (e.g. ownership, account existence) intact
+- [x] 3.2 Update `ExpenseRepository.create` INSERT column list, placeholders, and params to include `transaction_amount`
+- [x] 3.3 Update `ExpenseRepository.bulkInsert` column list, per-row placeholders, and params to include `transaction_amount`
+- [x] 3.4 Update `ExpenseRepository.update` SET clause and params to include `transaction_amount`
+
+## 4. Search by transaction amount
+
+- [x] 4.1 Add a `BigDecimal transactionAmount` parameter to `ExpenseRepository.findByFiltersCursor` and append `AND transaction_amount = ?` when non-null (placed with the other optional predicates, before the cursor clause)
+- [x] 4.2 Thread `transactionAmount` through `ExpenseService.listForOwner`, `listByUser`, and `listByAccount`
+- [x] 4.3 Add an optional `@RequestParam(value = "transaction_amount", required = false) BigDecimal transactionAmount` to `ExpenseController.list` and pass it to `listByUser`
+
+## 5. Tests
+
+- [x] 5.1 `ExpenseRepositoryTest`: create/bulk/update persist and read back `transaction_amount`; `findByFiltersCursor` filters by exact `transaction_amount` and combines with `account_id`
+- [x] 5.2 `ExpenseServiceTest`: null `transactionAmount` defaults to `amount` on create/bulk (and is returned); supplied `transactionAmount` is preserved; on update a null `amount` preserves the stored amount (no 400) and a null `transactionAmount` preserves the stored value (not re-defaulted); explicit update changes both; split lines with the same `transactionAmount` keep distinct amounts; listing filters by `transactionAmount`; absent filter is unconstrained
+- [x] 5.3 `ExpenseControllerTest`: `transaction_amount` query param is bound and forwarded; create/update round-trip the field
+- [x] 5.4 `ExpenseControllerIT`: end-to-end split-and-search — create multiple lines sharing a `transactionAmount`, then `GET /expenses?transaction_amount=...` returns exactly those lines with cursor pagination intact
+
+## 6. Verify
+
+- [x] 6.1 Run `./gradlew test integrationTest` and confirm the suite passes

--- a/src/integrationTest/java/com/novelosoftware/expenses/controllers/ExpenseControllerIT.java
+++ b/src/integrationTest/java/com/novelosoftware/expenses/controllers/ExpenseControllerIT.java
@@ -800,4 +800,116 @@ class ExpenseControllerIT extends BaseIT {
             .andExpect(jsonPath("$.code").value("NOT_FOUND"))
             .andExpect(jsonPath("$.message").value("Account with ID 999999 not found."));
     }
+
+    // -------------------------------------------------------------------------
+    // transactionAmount: split-and-search, creation default, partial update
+    // -------------------------------------------------------------------------
+
+    @Test
+    void create_withoutTransactionAmount_defaultsToAmount() throws Exception {
+        mockMvc.perform(post("/expenses")
+                .with(fullScopeJwtAs(USER))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "value": { "expenseDate": "2026-05-27", "accountId": %d,
+                      "amount": 42.50, "description": "Solo expense",
+                      "subCategory": "RESTAURANT", "createdBy": "user-expense-it" } }
+                """.formatted(firstAccountId)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.value.amount").value(42.50))
+            .andExpect(jsonPath("$.value.transactionAmount").value(42.50));
+    }
+
+    @Test
+    void splitTransaction_searchByTransactionAmount_returnsOnlyMatchingLines() throws Exception {
+        // One $100 transaction split into two lines, both carrying transactionAmount = 100.00.
+        createExpenseWithTransactionAmount(firstAccountId, USER, "2026-05-10", "60.00", "100.00");
+        createExpenseWithTransactionAmount(firstAccountId, USER, "2026-05-12", "40.00", "100.00");
+        // An unrelated expense with a different transaction amount must be excluded.
+        createExpenseWithTransactionAmount(firstAccountId, USER, "2026-05-15", "25.00", "25.00");
+
+        mockMvc.perform(get("/expenses")
+                .with(fullScopeJwtAs(USER))
+                .param("user_id", USER)
+                .param("start_date", "2026-05-01")
+                .param("end_date", "2026-05-31")
+                .param("transaction_amount", "100.00"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content.length()").value(2))
+            .andExpect(jsonPath("$.content[0].expenseDate").value("2026-05-12"))
+            .andExpect(jsonPath("$.content[0].amount").value(40.00))
+            .andExpect(jsonPath("$.content[0].transactionAmount").value(100.00))
+            .andExpect(jsonPath("$.content[1].expenseDate").value("2026-05-10"))
+            .andExpect(jsonPath("$.content[1].amount").value(60.00))
+            .andExpect(jsonPath("$.content[1].transactionAmount").value(100.00));
+    }
+
+    @Test
+    void splitTransaction_searchByTransactionAmount_cursorPaginationIntact() throws Exception {
+        createExpenseWithTransactionAmount(firstAccountId, USER, "2026-05-10", "60.00", "100.00");
+        createExpenseWithTransactionAmount(firstAccountId, USER, "2026-05-12", "40.00", "100.00");
+
+        // First page with limit 1: newest matching line, plus a nextCursor.
+        String firstPage = mockMvc.perform(get("/expenses")
+                .with(fullScopeJwtAs(USER))
+                .param("user_id", USER)
+                .param("start_date", "2026-05-01")
+                .param("end_date", "2026-05-31")
+                .param("transaction_amount", "100.00")
+                .param("limit", "1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content.length()").value(1))
+            .andExpect(jsonPath("$.content[0].expenseDate").value("2026-05-12"))
+            .andExpect(jsonPath("$.nextCursor").isNotEmpty())
+            .andReturn().getResponse().getContentAsString();
+
+        String cursor = objectMapper.readTree(firstPage).path("nextCursor").asText();
+
+        // Second page: the older matching line, with the filter resupplied alongside the cursor.
+        mockMvc.perform(get("/expenses")
+                .with(fullScopeJwtAs(USER))
+                .param("user_id", USER)
+                .param("start_date", "2026-05-01")
+                .param("end_date", "2026-05-31")
+                .param("transaction_amount", "100.00")
+                .param("limit", "1")
+                .param("cursor", cursor))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content.length()").value(1))
+            .andExpect(jsonPath("$.content[0].expenseDate").value("2026-05-10"))
+            .andExpect(jsonPath("$.content[0].transactionAmount").value(100.00));
+    }
+
+    @Test
+    void update_omittingTransactionAmount_preservesStoredValue() throws Exception {
+        long expenseId = createExpenseWithTransactionAmount(firstAccountId, USER, "2026-05-10", "60.00", "100.00");
+
+        // Change the amount but omit transactionAmount: stored 100.00 must be preserved (not re-defaulted to 70.00).
+        mockMvc.perform(put("/expenses/" + expenseId)
+                .with(fullScopeJwtAs(USER))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "value": { "expenseId": %d, "expenseDate": "2026-05-10", "accountId": %d,
+                      "amount": 70.00, "description": "Test expense",
+                      "subCategory": "RESTAURANT", "createdBy": "%s" } }
+                """.formatted(expenseId, firstAccountId, USER)))
+            .andExpect(status().is2xxSuccessful())
+            .andExpect(jsonPath("$.value.amount").value(70.00))
+            .andExpect(jsonPath("$.value.transactionAmount").value(100.00));
+    }
+
+    private long createExpenseWithTransactionAmount(long accountId, String userId, String date,
+                                                    String amount, String transactionAmount) throws Exception {
+        String response = mockMvc.perform(post("/expenses")
+                .with(fullScopeJwtAs(userId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "value": { "expenseDate": "%s", "accountId": %d, "amount": %s,
+                      "transactionAmount": %s, "description": "Split line",
+                      "subCategory": "RESTAURANT", "createdBy": "%s" } }
+                    """.formatted(date, accountId, amount, transactionAmount, userId)))
+            .andExpect(status().isCreated())
+            .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(response).path("value").path("expenseId").asLong();
+    }
 }

--- a/src/integrationTest/java/com/novelosoftware/expenses/controllers/ExpenseControllerIT.java
+++ b/src/integrationTest/java/com/novelosoftware/expenses/controllers/ExpenseControllerIT.java
@@ -898,6 +898,19 @@ class ExpenseControllerIT extends BaseIT {
             .andExpect(jsonPath("$.value.transactionAmount").value(100.00));
     }
 
+    @Test
+    void create_transactionAmountTooPrecise_returns400() throws Exception {
+        mockMvc.perform(post("/expenses")
+                .with(fullScopeJwtAs(USER))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    { "value": { "expenseDate": "2026-05-27", "accountId": %d,
+                      "amount": 42.50, "transactionAmount": 100.123, "description": "Too precise",
+                      "subCategory": "RESTAURANT", "createdBy": "user-expense-it" } }
+                """.formatted(firstAccountId)))
+            .andExpect(status().isBadRequest());
+    }
+
     private long createExpenseWithTransactionAmount(long accountId, String userId, String date,
                                                     String amount, String transactionAmount) throws Exception {
         String response = mockMvc.perform(post("/expenses")

--- a/src/main/java/com/novelosoftware/expenses/controllers/ExpenseController.java
+++ b/src/main/java/com/novelosoftware/expenses/controllers/ExpenseController.java
@@ -24,6 +24,7 @@ import com.novelosoftware.expenses.dto.UpdateExpenseRequest;
 import com.novelosoftware.expenses.dto.UpdateExpenseResponse;
 import com.novelosoftware.expenses.services.ExpenseService;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 /**
@@ -53,6 +54,7 @@ public class ExpenseController {
      * @param category    optional category filter; mutually exclusive with subcategory
      * @param subcategory optional subcategory filter; mutually exclusive with category
      * @param accountId   optional account filter
+     * @param transactionAmount optional exact-match filter on the original transaction amount
      * @return a page of expenses and an optional next-page cursor
      */
     @GetMapping
@@ -67,9 +69,10 @@ public class ExpenseController {
             @RequestParam(value = "cursor", required = false) String cursor,
             @RequestParam(value = "category", required = false) String category,
             @RequestParam(value = "subcategory", required = false) String subcategory,
-            @RequestParam(value = "account_id", required = false) Long accountId) {
+            @RequestParam(value = "account_id", required = false) Long accountId,
+            @RequestParam(value = "transaction_amount", required = false) BigDecimal transactionAmount) {
 
-        return expenseService.listByUser(userId, startDate, endDate, limit, cursor, category, subcategory, accountId);
+        return expenseService.listByUser(userId, startDate, endDate, limit, cursor, category, subcategory, accountId, transactionAmount);
     }
 
     /**

--- a/src/main/java/com/novelosoftware/expenses/dto/Expense.java
+++ b/src/main/java/com/novelosoftware/expenses/dto/Expense.java
@@ -15,6 +15,8 @@ public record Expense(
     Long accountId,
     /** amount of the expense */
     BigDecimal amount,
+    /** amount of the original (pre-split) transaction this line was derived from */
+    BigDecimal transactionAmount,
     /** description of the expense */
     String description,
     /** sub-category o the expense, category can be infered from here */
@@ -32,6 +34,7 @@ public record Expense(
             .expenseDate(expenseDate)
             .accountId(accountId)
             .amount(amount)
+            .transactionAmount(transactionAmount)
             .description(description)
             .subCategory(subCategory)
             .createdBy(createdBy);
@@ -42,6 +45,7 @@ public record Expense(
         private LocalDate expenseDate;
         private Long accountId;
         private BigDecimal amount;
+        private BigDecimal transactionAmount;
         private String description;
         private SubCategory subCategory;
         private String createdBy;
@@ -52,12 +56,13 @@ public record Expense(
         public Builder expenseDate(LocalDate expenseDate) { this.expenseDate = expenseDate; return this; }
         public Builder accountId(Long accountId) { this.accountId = accountId; return this; }
         public Builder amount(BigDecimal amount) { this.amount = amount; return this; }
+        public Builder transactionAmount(BigDecimal transactionAmount) { this.transactionAmount = transactionAmount; return this; }
         public Builder description(String description) { this.description = description; return this; }
         public Builder subCategory(SubCategory subCategory) { this.subCategory = subCategory; return this; }
         public Builder createdBy(String createdBy) { this.createdBy = createdBy; return this; }
 
         public Expense build() {
-            return new Expense(expenseId, expenseDate, accountId, amount, description, subCategory, createdBy);
+            return new Expense(expenseId, expenseDate, accountId, amount, transactionAmount, description, subCategory, createdBy);
         }
     }
 }

--- a/src/main/java/com/novelosoftware/expenses/entities/ExpenseEntity.java
+++ b/src/main/java/com/novelosoftware/expenses/entities/ExpenseEntity.java
@@ -16,6 +16,8 @@ public record ExpenseEntity(
     Long accountId,
     /** Amount spent. */
     BigDecimal amount,
+    /** Amount of the original (pre-split) transaction this line was derived from. */
+    BigDecimal transactionAmount,
     /** Description of what the expense was for. */
     String description,
     /** Top-level category (e.g. Food, Transport). */
@@ -35,6 +37,7 @@ public record ExpenseEntity(
             .expenseDate(expenseDate)
             .accountId(accountId)
             .amount(amount)
+            .transactionAmount(transactionAmount)
             .description(description)
             .category(category)
             .subcategory(subcategory)
@@ -46,6 +49,7 @@ public record ExpenseEntity(
         private LocalDate expenseDate;
         private Long accountId;
         private BigDecimal amount;
+        private BigDecimal transactionAmount;
         private String description;
         private String category;
         private String subcategory;
@@ -57,13 +61,14 @@ public record ExpenseEntity(
         public Builder expenseDate(LocalDate expenseDate) { this.expenseDate = expenseDate; return this; }
         public Builder accountId(Long accountId) { this.accountId = accountId; return this; }
         public Builder amount(BigDecimal amount) { this.amount = amount; return this; }
+        public Builder transactionAmount(BigDecimal transactionAmount) { this.transactionAmount = transactionAmount; return this; }
         public Builder description(String description) { this.description = description; return this; }
         public Builder category(String category) { this.category = category; return this; }
         public Builder subcategory(String subcategory) { this.subcategory = subcategory; return this; }
         public Builder createdBy(String createdBy) { this.createdBy = createdBy; return this; }
 
         public ExpenseEntity build() {
-            return new ExpenseEntity(expenseId, expenseDate, accountId, amount, description, category, subcategory, createdBy);
+            return new ExpenseEntity(expenseId, expenseDate, accountId, amount, transactionAmount, description, category, subcategory, createdBy);
         }
     }
 }

--- a/src/main/java/com/novelosoftware/expenses/mappers/ExpenseMapper.java
+++ b/src/main/java/com/novelosoftware/expenses/mappers/ExpenseMapper.java
@@ -22,6 +22,7 @@ public final class ExpenseMapper {
             expense.expenseDate(),
             expense.accountId(),
             expense.amount(),
+            expense.transactionAmount(),
             expense.description(),
             CategoryMapper.getCategory(expense.subCategory()).name(),
             expense.subCategory().name(),
@@ -40,6 +41,7 @@ public final class ExpenseMapper {
             entity.expenseDate(),
             entity.accountId(),
             entity.amount(),
+            entity.transactionAmount(),
             entity.description(),
             SubCategory.valueOf(entity.subcategory()),
             entity.createdBy()

--- a/src/main/java/com/novelosoftware/expenses/repositories/ExpenseRepository.java
+++ b/src/main/java/com/novelosoftware/expenses/repositories/ExpenseRepository.java
@@ -30,6 +30,7 @@ public class ExpenseRepository {
         rs.getObject("expense_date", LocalDate.class),
         rs.getLong("account_id"),
         rs.getBigDecimal("amount"),
+        rs.getBigDecimal("transaction_amount"),
         rs.getString("description"),
         rs.getString("category"),
         rs.getString("subcategory"),
@@ -57,12 +58,12 @@ public class ExpenseRepository {
      */
     public ExpenseEntity create(ExpenseEntity entity) {
         var sql = """
-            INSERT INTO expenses (expense_date, account_id, amount, description, category, subcategory, created_by)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO expenses (expense_date, account_id, amount, transaction_amount, description, category, subcategory, created_by)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             RETURNING *
             """;
         return jdbc.queryForObject(sql, MAPPER,
-            entity.expenseDate(), entity.accountId(), entity.amount(),
+            entity.expenseDate(), entity.accountId(), entity.amount(), entity.transactionAmount(),
             entity.description(), entity.category(), entity.subcategory(), entity.createdBy());
     }
 
@@ -80,16 +81,17 @@ public class ExpenseRepository {
     public List<ExpenseEntity> bulkInsert(List<ExpenseEntity> entities) {
         var sql = new StringBuilder(
             "WITH inserted AS (INSERT INTO expenses " +
-            "(expense_date, account_id, amount, description, category, subcategory, created_by) VALUES ");
+            "(expense_date, account_id, amount, transaction_amount, description, category, subcategory, created_by) VALUES ");
 
         var params = new ArrayList<>();
         for (int i = 0; i < entities.size(); i++) {
             if (i > 0) sql.append(", ");
-            sql.append("(?, ?, ?, ?, ?, ?, ?)");
+            sql.append("(?, ?, ?, ?, ?, ?, ?, ?)");
             ExpenseEntity e = entities.get(i);
             params.add(e.expenseDate());
             params.add(e.accountId());
             params.add(e.amount());
+            params.add(e.transactionAmount());
             params.add(e.description());
             params.add(e.category());
             params.add(e.subcategory());
@@ -112,13 +114,13 @@ public class ExpenseRepository {
     public Optional<ExpenseEntity> update(Long id, ExpenseEntity entity) {
         var sql = """
             UPDATE expenses
-            SET expense_date = ?, account_id = ?, amount = ?,
+            SET expense_date = ?, account_id = ?, amount = ?, transaction_amount = ?,
                 description = ?, category = ?, subcategory = ?
             WHERE expense_id = ?
             RETURNING *
             """;
         var results = jdbc.query(sql, MAPPER,
-            entity.expenseDate(), entity.accountId(), entity.amount(),
+            entity.expenseDate(), entity.accountId(), entity.amount(), entity.transactionAmount(),
             entity.description(), entity.category(), entity.subcategory(), id);
         return results.stream().findFirst();
     }
@@ -156,6 +158,7 @@ public class ExpenseRepository {
      * @param category    optional category filter; mutually exclusive with subcategory
      * @param subcategory optional subcategory filter; mutually exclusive with category
      * @param accountId   optional account filter
+     * @param transactionAmount optional exact-match filter on the original transaction amount
      * @param limit       maximum number of results to return
      * @param cursor      optional cursor from the previous page; {@code null} for the first page
      * @return list of expense entities for the requested page
@@ -163,6 +166,7 @@ public class ExpenseRepository {
     public List<ExpenseEntity> findByFiltersCursor(
             String userId, LocalDate startDate, LocalDate endDate,
             String category, String subcategory, Long accountId,
+            BigDecimal transactionAmount,
             int limit,
             ExpenseCursor.DecodedCursor cursor) {
 
@@ -186,6 +190,10 @@ public class ExpenseRepository {
         if (accountId != null) {
             sql.append("AND account_id = ? ");
             params.add(accountId);
+        }
+        if (transactionAmount != null) {
+            sql.append("AND transaction_amount = ? ");
+            params.add(transactionAmount);
         }
         if (cursor != null) {
             sql.append("AND (expense_date < ? OR (expense_date = ? AND expense_id < ?)) ");

--- a/src/main/java/com/novelosoftware/expenses/services/ExpenseService.java
+++ b/src/main/java/com/novelosoftware/expenses/services/ExpenseService.java
@@ -319,6 +319,11 @@ public class ExpenseService {
             throw createValidationException("amount cannot be null");
         }
 
+        // Reject values that exceed the NUMERIC(15,2) column so a precision overflow surfaces as a
+        // 400 rather than a database 500, and so a too-precise value is not silently rounded on write.
+        validateMonetaryScale(expense.amount(), "amount");
+        validateMonetaryScale(expense.transactionAmount(), "transactionAmount");
+
         if (expense.description() == null || expense.description().isEmpty()) {
             throw createValidationException("description cannot be null");
         }
@@ -339,5 +344,27 @@ public class ExpenseService {
         // Resolve the account through the ownership-checked accessor so a missing account and
         // someone else's account are both hidden as 404 (no existence disclosure).
         accountService.getById(expense.accountId(), false);
+    }
+
+    /** Monetary columns are NUMERIC(15,2): up to 13 integer digits and 2 fractional digits. */
+    private static final int MONETARY_SCALE = 2;
+    private static final int MONETARY_INTEGER_DIGITS = 13;
+
+    /**
+     * Rejects a monetary value that would not fit the {@code NUMERIC(15,2)} column: more than two
+     * fractional digits (which the database would silently round) or more than thirteen integer
+     * digits (which the database would reject with a server error). Null is allowed and skipped.
+     */
+    private void validateMonetaryScale(BigDecimal value, String field) {
+        if (value == null) {
+            return;
+        }
+        if (value.scale() > MONETARY_SCALE) {
+            throw createValidationException(field + " must have at most " + MONETARY_SCALE + " decimal places");
+        }
+        // precision() - scale() is the number of integer digits (an upper bound when scale < 0).
+        if (value.precision() - value.scale() > MONETARY_INTEGER_DIGITS) {
+            throw createValidationException(field + " must have at most " + MONETARY_INTEGER_DIGITS + " integer digits");
+        }
     }
 }

--- a/src/main/java/com/novelosoftware/expenses/services/ExpenseService.java
+++ b/src/main/java/com/novelosoftware/expenses/services/ExpenseService.java
@@ -19,6 +19,7 @@ import com.novelosoftware.expenses.util.DateWindowResolver;
 import com.novelosoftware.expenses.util.DateWindow;
 import com.novelosoftware.expenses.util.ExpenseCursor;
 
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.util.List;
@@ -70,8 +71,8 @@ public class ExpenseService {
                 if (req == null || req.value() == null) {
                     throw createValidationException("Expense payload not provided");
                 }
-                expenseWriteValidations(req.value(), callerSub);
-                return ExpenseMapper.toEntity(req.value());
+                expenseWriteValidations(req.value(), callerSub, true);
+                return defaultTransactionAmount(ExpenseMapper.toEntity(req.value()));
             })
             .toList();
 
@@ -91,9 +92,9 @@ public class ExpenseService {
         }
 
         Expense expense = request.value();
-        expenseWriteValidations(expense, currentUser.requireSubject());
+        expenseWriteValidations(expense, currentUser.requireSubject(), true);
 
-        ExpenseEntity expenseEntity = ExpenseMapper.toEntity(expense);
+        ExpenseEntity expenseEntity = defaultTransactionAmount(ExpenseMapper.toEntity(expense));
         ExpenseEntity createdEntity = repo.create(expenseEntity);
         return new CreateExpenseResponse(ExpenseMapper.toDto(createdEntity));
     }
@@ -131,7 +132,9 @@ public class ExpenseService {
 
         String callerSub = currentUser.requireSubject();
         Expense expense = request.value();
-        expenseWriteValidations(expense, callerSub);
+        // amount and transactionAmount are partial on update: a null value preserves the stored
+        // value rather than failing validation, so amount is not required here.
+        expenseWriteValidations(expense, callerSub, false);
 
         // Payload is validated; bring previous version and make sure the caller owns it.
         ExpenseEntity oldExpense = repo.get(id).orElseThrow(() -> createExpenseNotFoundException(id));
@@ -141,7 +144,9 @@ public class ExpenseService {
             throw createExpenseNotFoundException(id);
         }
 
-        ExpenseEntity newExpense = ExpenseMapper.toEntity(expense);
+        // Preserve the stored amount / transactionAmount when the request omits them. The
+        // create-time "null transactionAmount defaults to amount" rule does NOT apply on update.
+        ExpenseEntity newExpense = mergeUpdateValues(ExpenseMapper.toEntity(expense), oldExpense);
         ExpenseEntity updatedEntity = repo.update(id, newExpense).orElseThrow(() -> createExpenseNotFoundException(id));
         return new UpdateExpenseResponse(ExpenseMapper.toDto(updatedEntity));
     }
@@ -168,6 +173,7 @@ public class ExpenseService {
      * @param category    optional category filter; mutually exclusive with subcategory
      * @param subcategory optional subcategory filter; mutually exclusive with category
      * @param accountId   optional account filter
+     * @param transactionAmount optional exact-match filter on the original transaction amount
      * @return a page of expenses with an optional next-page cursor
      */
     public CursorPageResponse<Expense> listByUser(String userId,
@@ -177,7 +183,8 @@ public class ExpenseService {
                                                    String cursorToken,
                                                    String category,
                                                    String subcategory,
-                                                   Long accountId) {
+                                                   Long accountId,
+                                                   BigDecimal transactionAmount) {
         // The requested user is optional and defaults to the caller. When supplied it must
         // match the caller; a mismatch is hidden as a 404 (ADMIN cross-user access is deferred).
         String callerSub = currentUser.requireSubject();
@@ -186,7 +193,7 @@ public class ExpenseService {
             throw createExpenseNotFoundException("No expenses found for the requested user");
         }
 
-        return listForOwner(requestedUser, startDate, endDate, limit, cursorToken, category, subcategory, accountId);
+        return listForOwner(requestedUser, startDate, endDate, limit, cursorToken, category, subcategory, accountId, transactionAmount);
     }
 
     /**
@@ -205,7 +212,8 @@ public class ExpenseService {
                                                       String subcategory) {
         // Ownership-checked: a non-owned or missing account is hidden as 404.
         String owner = accountService.getById(accountId, false).createdBy();
-        return listForOwner(owner, startDate, endDate, limit, cursorToken, category, subcategory, accountId);
+        // The transaction_amount filter is exposed only on GET /expenses, so account listing passes null.
+        return listForOwner(owner, startDate, endDate, limit, cursorToken, category, subcategory, accountId, null);
     }
 
     /**
@@ -219,7 +227,8 @@ public class ExpenseService {
                                                      String cursorToken,
                                                      String category,
                                                      String subcategory,
-                                                     Long accountId) {
+                                                     Long accountId,
+                                                     BigDecimal transactionAmount) {
         // --- Validate mutually exclusive filters ---
         if (category != null && subcategory != null) {
             throw createValidationException("category and subcategory are mutually exclusive; provide at most one");
@@ -249,7 +258,7 @@ public class ExpenseService {
         // --- Fetch and map ---
         List<ExpenseEntity> entities = repo.findByFiltersCursor(
             userId, window.startDate(), window.endDate(),
-            category, subcategory, accountId,
+            category, subcategory, accountId, transactionAmount,
             resolvedLimit, cursor);
         List<Expense> expenses = entities.stream().map(ExpenseMapper::toDto).toList();
 
@@ -263,7 +272,41 @@ public class ExpenseService {
         return new CursorPageResponse<>(expenses, nextCursor, resolvedLimit);
     }
 
-    private void expenseWriteValidations(Expense expense, String callerSub) {
+    /**
+     * Creation-only default: when the caller omits {@code transactionAmount}, set it to the line's
+     * own {@code amount}. Never derived from splits or amount edits.
+     */
+    private static ExpenseEntity defaultTransactionAmount(ExpenseEntity entity) {
+        if (entity.transactionAmount() != null) {
+            return entity;
+        }
+        return entity.toBuilder().transactionAmount(entity.amount()).build();
+    }
+
+    /**
+     * Merges a partial update onto the stored entity: a null {@code amount} or
+     * {@code transactionAmount} in the incoming payload preserves the existing stored value.
+     * Unlike creation, a null {@code transactionAmount} is NOT re-defaulted to {@code amount}.
+     */
+    private static ExpenseEntity mergeUpdateValues(ExpenseEntity incoming, ExpenseEntity existing) {
+        var builder = incoming.toBuilder();
+        if (incoming.amount() == null) {
+            builder.amount(existing.amount());
+        }
+        if (incoming.transactionAmount() == null) {
+            builder.transactionAmount(existing.transactionAmount());
+        }
+        return builder.build();
+    }
+
+    /**
+     * Validates an expense write payload.
+     *
+     * @param amountRequired when {@code true} a null {@code amount} is rejected (create/bulk);
+     *                       when {@code false} a null {@code amount} is allowed (update treats it
+     *                       as "leave unchanged")
+     */
+    private void expenseWriteValidations(Expense expense, String callerSub, boolean amountRequired) {
         if (expense.expenseDate() == null) {
             throw createValidationException("expenseDate cannot be null");
         }
@@ -272,7 +315,7 @@ public class ExpenseService {
             throw createValidationException("accountId cannot be null");
         }
 
-        if (expense.amount() == null) {
+        if (amountRequired && expense.amount() == null) {
             throw createValidationException("amount cannot be null");
         }
 

--- a/src/main/java/com/novelosoftware/expenses/services/ExpenseService.java
+++ b/src/main/java/com/novelosoftware/expenses/services/ExpenseService.java
@@ -32,6 +32,10 @@ import static com.novelosoftware.expenses.exceptions.ExpenseServiceExceptions.*;
 @Service
 public class ExpenseService {
 
+    /** Monetary columns are NUMERIC(15,2): up to 13 integer digits and 2 fractional digits. */
+    private static final int MONETARY_SCALE = 2;
+    private static final int MONETARY_INTEGER_DIGITS = 13;
+
     private final ExpenseRepository repo;
     private final AccountService accountService;
     private final CurrentUser currentUser;
@@ -71,7 +75,8 @@ public class ExpenseService {
                 if (req == null || req.value() == null) {
                     throw createValidationException("Expense payload not provided");
                 }
-                expenseWriteValidations(req.value(), callerSub, true);
+                expenseWriteValidations(req.value(), callerSub);
+                requireAmount(req.value());
                 return defaultTransactionAmount(ExpenseMapper.toEntity(req.value()));
             })
             .toList();
@@ -92,7 +97,8 @@ public class ExpenseService {
         }
 
         Expense expense = request.value();
-        expenseWriteValidations(expense, currentUser.requireSubject(), true);
+        expenseWriteValidations(expense, currentUser.requireSubject());
+        requireAmount(expense);
 
         ExpenseEntity expenseEntity = defaultTransactionAmount(ExpenseMapper.toEntity(expense));
         ExpenseEntity createdEntity = repo.create(expenseEntity);
@@ -133,8 +139,8 @@ public class ExpenseService {
         String callerSub = currentUser.requireSubject();
         Expense expense = request.value();
         // amount and transactionAmount are partial on update: a null value preserves the stored
-        // value rather than failing validation, so amount is not required here.
-        expenseWriteValidations(expense, callerSub, false);
+        // value rather than failing validation, so requireAmount is intentionally not called here.
+        expenseWriteValidations(expense, callerSub);
 
         // Payload is validated; bring previous version and make sure the caller owns it.
         ExpenseEntity oldExpense = repo.get(id).orElseThrow(() -> createExpenseNotFoundException(id));
@@ -299,24 +305,25 @@ public class ExpenseService {
         return builder.build();
     }
 
+    /** Rejects a null {@code amount}. Called only on create/bulk, where amount is required. */
+    private void requireAmount(Expense expense) {
+        if (expense.amount() == null) {
+            throw createValidationException("amount cannot be null");
+        }
+    }
+
     /**
-     * Validates an expense write payload.
-     *
-     * @param amountRequired when {@code true} a null {@code amount} is rejected (create/bulk);
-     *                       when {@code false} a null {@code amount} is allowed (update treats it
-     *                       as "leave unchanged")
+     * Validates an expense write payload. {@code amount} presence is NOT checked here — on update it
+     * is optional (a null preserves the stored value); callers that require it invoke
+     * {@link #requireAmount(Expense)} themselves.
      */
-    private void expenseWriteValidations(Expense expense, String callerSub, boolean amountRequired) {
+    private void expenseWriteValidations(Expense expense, String callerSub) {
         if (expense.expenseDate() == null) {
             throw createValidationException("expenseDate cannot be null");
         }
 
         if (expense.accountId() == null) {
             throw createValidationException("accountId cannot be null");
-        }
-
-        if (amountRequired && expense.amount() == null) {
-            throw createValidationException("amount cannot be null");
         }
 
         // Reject values that exceed the NUMERIC(15,2) column so a precision overflow surfaces as a
@@ -345,10 +352,6 @@ public class ExpenseService {
         // someone else's account are both hidden as 404 (no existence disclosure).
         accountService.getById(expense.accountId(), false);
     }
-
-    /** Monetary columns are NUMERIC(15,2): up to 13 integer digits and 2 fractional digits. */
-    private static final int MONETARY_SCALE = 2;
-    private static final int MONETARY_INTEGER_DIGITS = 13;
 
     /**
      * Rejects a monetary value that would not fit the {@code NUMERIC(15,2)} column: more than two

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -33,3 +33,7 @@ ALTER TABLE accounts ADD COLUMN IF NOT EXISTS period_start DATE;
 
 -- Bounds the account gap aggregation (SUM of expenses for an account since period_start).
 CREATE INDEX IF NOT EXISTS idx_expenses_account_date ON expenses(account_id, expense_date);
+
+-- Original (pre-split) transaction total carried on each expense line. Nullable for existing
+-- rows; new rows default it to the line's amount at the service layer. No index in this change.
+ALTER TABLE expenses ADD COLUMN IF NOT EXISTS transaction_amount NUMERIC(15, 2);

--- a/src/test/java/com/novelosoftware/expenses/controllers/AccountControllerTest.java
+++ b/src/test/java/com/novelosoftware/expenses/controllers/AccountControllerTest.java
@@ -145,7 +145,7 @@ class AccountControllerTest {
     @Test
     void listExpenses_accountExists_returns200WithPage() throws Exception {
         Expense expense = new Expense(10L, LocalDate.of(2026, 5, 10), 1L,
-            new BigDecimal("42.50"), "Tacos", SubCategory.RESTAURANT, "user-1");
+            new BigDecimal("42.50"), new BigDecimal("42.50"), "Tacos", SubCategory.RESTAURANT, "user-1");
         CursorPageResponse<Expense> page = new CursorPageResponse<>(List.of(expense), null, 20);
 
         // Ownership is enforced inside listByAccount, so the controller just delegates.

--- a/src/test/java/com/novelosoftware/expenses/controllers/ExpenseControllerTest.java
+++ b/src/test/java/com/novelosoftware/expenses/controllers/ExpenseControllerTest.java
@@ -252,7 +252,8 @@ public class ExpenseControllerTest {
         when(expenseService.listByUser(any(), any(), any(), any(), any(),
             expectedCategory == null ? isNull() : eq(expectedCategory),
             expectedSubcategory == null ? isNull() : eq(expectedSubcategory),
-            expectedAccountId == null ? isNull() : eq(expectedAccountId)))
+            expectedAccountId == null ? isNull() : eq(expectedAccountId),
+            isNull()))
             .thenReturn(new com.novelosoftware.expenses.dto.CursorPageResponse<>(List.of(), null, 20));
 
         var request = get("/expenses").param("user_id", "user-1");
@@ -265,7 +266,23 @@ public class ExpenseControllerTest {
         verify(expenseService).listByUser(eq("user-1"), isNull(), isNull(), isNull(), isNull(),
             expectedCategory == null ? isNull() : eq(expectedCategory),
             expectedSubcategory == null ? isNull() : eq(expectedSubcategory),
-            expectedAccountId == null ? isNull() : eq(expectedAccountId));
+            expectedAccountId == null ? isNull() : eq(expectedAccountId),
+            isNull());
+    }
+
+    @Test
+    void list_transactionAmount_delegatesToService() throws Exception {
+        when(expenseService.listByUser(any(), any(), any(), any(), any(),
+            isNull(), isNull(), isNull(), eq(new BigDecimal("100.00"))))
+            .thenReturn(new com.novelosoftware.expenses.dto.CursorPageResponse<>(List.of(), null, 20));
+
+        mockMvc.perform(get("/expenses")
+                .param("user_id", "user-1")
+                .param("transaction_amount", "100.00"))
+            .andExpect(status().isOk());
+
+        verify(expenseService).listByUser(eq("user-1"), isNull(), isNull(), isNull(), isNull(),
+            isNull(), isNull(), isNull(), eq(new BigDecimal("100.00")));
     }
 
     static Stream<Arguments> filterCombinations() {
@@ -282,7 +299,7 @@ public class ExpenseControllerTest {
     @Test
     void list_categoryAndSubcategoryBothProvided_returns400() throws Exception {
         when(expenseService.listByUser(any(), any(), any(), any(), any(),
-            eq("Food"), eq("Groceries"), isNull()))
+            eq("Food"), eq("Groceries"), isNull(), isNull()))
             .thenThrow(com.novelosoftware.expenses.exceptions.ExpenseServiceExceptions
                 .createValidationException("category and subcategory are mutually exclusive; provide at most one"));
 
@@ -347,8 +364,10 @@ public class ExpenseControllerTest {
         return new Expense(
             id,
             LocalDate.of(2026, 5, 25), 
-            1L, 
+            1L,
             new BigDecimal("1000.00"),
+            // Payloads omit transactionAmount, so the deserialized request carries null here.
+            null,
             "Expensive Tacos",
             SubCategory.RESTAURANT,
             "user-1");

--- a/src/test/java/com/novelosoftware/expenses/repositories/ExpenseRepositoryTest.java
+++ b/src/test/java/com/novelosoftware/expenses/repositories/ExpenseRepositoryTest.java
@@ -31,7 +31,7 @@ class ExpenseRepositoryTest {
     void create_insertsAndReturnsEntity() {
         var entity = anEntity(null);
         when(jdbc.queryForObject(anyString(), any(RowMapper.class),
-            any(), any(), any(), any(), any(), any(), any()))
+            any(), any(), any(), any(), any(), any(), any(), any()))
             .thenReturn(anEntity(1L));
 
         var result = repo.create(entity);
@@ -39,13 +39,13 @@ class ExpenseRepositoryTest {
         assertNotNull(result);
         assertEquals(1L, result.expenseId());
         verify(jdbc).queryForObject(anyString(), any(RowMapper.class),
-            any(), any(), any(), any(), any(), any(), any());
+            any(), any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
     void update_returnsUpdatedEntity() {
         when(jdbc.query(anyString(), any(RowMapper.class),
-            any(), any(), any(), any(), any(), any(), eq(1L)))
+            any(), any(), any(), any(), any(), any(), any(), eq(1L)))
             .thenReturn(List.of(anEntity(1L)));
 
         Optional<ExpenseEntity> result = repo.update(1L, anEntity(1L));
@@ -57,7 +57,7 @@ class ExpenseRepositoryTest {
     @Test
     void update_returnsEmptyWhenNotFound() {
         when(jdbc.query(anyString(), any(RowMapper.class),
-            any(), any(), any(), any(), any(), any(), eq(99L)))
+            any(), any(), any(), any(), any(), any(), any(), eq(99L)))
             .thenReturn(List.of());
 
         Optional<ExpenseEntity> result = repo.update(99L, anEntity(null));
@@ -110,7 +110,7 @@ class ExpenseRepositoryTest {
         when(jdbc.query(anyString(), any(RowMapper.class), eq("user-1"), eq(START), eq(END), eq(20)))
             .thenReturn(List.of(anEntity(1L)));
 
-        var result = repo.findByFiltersCursor("user-1", START, END, null, null, null, 20, null);
+        var result = repo.findByFiltersCursor("user-1", START, END, null, null, null, null, 20, null);
 
         assertEquals(1, result.size());
         assertEquals(1L, result.get(0).expenseId());
@@ -128,7 +128,7 @@ class ExpenseRepositoryTest {
             eq(20)))
             .thenReturn(List.of(anEntity(3L)));
 
-        var result = repo.findByFiltersCursor("user-1", START, END, null, null, null, 20, cursor);
+        var result = repo.findByFiltersCursor("user-1", START, END, null, null, null, null, 20, cursor);
 
         assertEquals(1, result.size());
         assertEquals(3L, result.get(0).expenseId());
@@ -144,7 +144,7 @@ class ExpenseRepositoryTest {
             eq("user-1"), eq(START), eq(END), eq("Food"), eq(20)))
             .thenReturn(List.of(anEntity(1L)));
 
-        var result = repo.findByFiltersCursor("user-1", START, END, "Food", null, null, 20, null);
+        var result = repo.findByFiltersCursor("user-1", START, END, "Food", null, null, null, 20, null);
 
         assertEquals(1, result.size());
     }
@@ -155,7 +155,7 @@ class ExpenseRepositoryTest {
             eq("user-1"), eq(START), eq(END), eq("Groceries"), eq(20)))
             .thenReturn(List.of(anEntity(1L)));
 
-        var result = repo.findByFiltersCursor("user-1", START, END, null, "Groceries", null, 20, null);
+        var result = repo.findByFiltersCursor("user-1", START, END, null, "Groceries", null, null, 20, null);
 
         assertEquals(1, result.size());
     }
@@ -166,7 +166,7 @@ class ExpenseRepositoryTest {
             eq("user-1"), eq(START), eq(END), eq(3L), eq(20)))
             .thenReturn(List.of(anEntity(1L)));
 
-        var result = repo.findByFiltersCursor("user-1", START, END, null, null, 3L, 20, null);
+        var result = repo.findByFiltersCursor("user-1", START, END, null, null, 3L, null, 20, null);
 
         assertEquals(1, result.size());
     }
@@ -181,7 +181,7 @@ class ExpenseRepositoryTest {
             eq("user-1"), eq(START), eq(END), eq("Food"), eq(3L), eq(20)))
             .thenReturn(List.of(anEntity(1L)));
 
-        var result = repo.findByFiltersCursor("user-1", START, END, "Food", null, 3L, 20, null);
+        var result = repo.findByFiltersCursor("user-1", START, END, "Food", null, 3L, null, 20, null);
 
         assertEquals(1, result.size());
     }
@@ -191,9 +191,33 @@ class ExpenseRepositoryTest {
         when(jdbc.query(anyString(), any(RowMapper.class), any()))
             .thenReturn(List.of());
 
-        var result = repo.findByFiltersCursor("user-1", START, END, null, null, null, 20, null);
+        var result = repo.findByFiltersCursor("user-1", START, END, null, null, null, null, 20, null);
 
         assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void findByFiltersCursor_transactionAmountFilter_passedAsParam() {
+        var txAmount = new BigDecimal("100.00");
+        when(jdbc.query(anyString(), any(RowMapper.class),
+            eq("user-1"), eq(START), eq(END), eq(txAmount), eq(20)))
+            .thenReturn(List.of(anEntity(1L)));
+
+        var result = repo.findByFiltersCursor("user-1", START, END, null, null, null, txAmount, 20, null);
+
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void findByFiltersCursor_transactionAmountAndAccountId_bothPassedAsParams() {
+        var txAmount = new BigDecimal("100.00");
+        when(jdbc.query(anyString(), any(RowMapper.class),
+            eq("user-1"), eq(START), eq(END), eq(3L), eq(txAmount), eq(20)))
+            .thenReturn(List.of(anEntity(1L)));
+
+        var result = repo.findByFiltersCursor("user-1", START, END, null, null, 3L, txAmount, 20, null);
+
+        assertEquals(1, result.size());
     }
 
     // -------------------------------------------------------------------------
@@ -202,6 +226,6 @@ class ExpenseRepositoryTest {
 
     private ExpenseEntity anEntity(Long id) {
         return new ExpenseEntity(id, LocalDate.of(2026, 1, 15), 1L,
-            new BigDecimal("50.00"), "Lunch", "Food", "Restaurants", "user-1");
+            new BigDecimal("50.00"), new BigDecimal("50.00"), "Lunch", "Food", "Restaurants", "user-1");
     }
 }

--- a/src/test/java/com/novelosoftware/expenses/services/ExpenseServiceTest.java
+++ b/src/test/java/com/novelosoftware/expenses/services/ExpenseServiceTest.java
@@ -74,6 +74,7 @@ public class ExpenseServiceTest {
         LocalDate.of(2026, 5, 25),
         ACCOUNT_ID,
         new BigDecimal("1000.00"),
+        new BigDecimal("1000.00"),
         "Expensive Tacos",
         SubCategory.RESTAURANT,
         "user-1");
@@ -82,6 +83,7 @@ public class ExpenseServiceTest {
         null,
         LocalDate.of(2026, 5, 25),
         ACCOUNT_ID,
+        new BigDecimal("1000.00"),
         new BigDecimal("1000.00"),
         "Expensive Tacos",
         CategoryMapper.getCategory(SubCategory.RESTAURANT).name(),
@@ -93,6 +95,7 @@ public class ExpenseServiceTest {
         LocalDate.of(2026, 5, 25),
         ACCOUNT_ID,
         new BigDecimal("1000.00"),
+        new BigDecimal("1000.00"),
         "Expensive Tacos",
         CategoryMapper.getCategory(SubCategory.RESTAURANT).name(),
         SubCategory.RESTAURANT.name(),
@@ -102,6 +105,7 @@ public class ExpenseServiceTest {
         EXPENSE_ID,
         LocalDate.of(2026, 5, 25),
         ACCOUNT_ID,
+        new BigDecimal("1000.00"),
         new BigDecimal("1000.00"),
         "Expensive Tacos",
         SubCategory.RESTAURANT,
@@ -211,7 +215,7 @@ public class ExpenseServiceTest {
     @Test
     void listByUser_requestedUserNotCaller_throwsExpenseNotFoundException() {
         assertThrows(ExpenseNotFoundException.class,
-            () -> service.listByUser("someone-else", null, null, null, null, null, null, null));
+            () -> service.listByUser("someone-else", null, null, null, null, null, null, null, null));
     }
 
     @Test
@@ -255,6 +259,70 @@ public class ExpenseServiceTest {
         verify(repo).update(EXPENSE_ID, updatedExpenseEntity);
     }
 
+    // -------------------------------------------------------------------------
+    // transactionAmount: creation default and partial update
+    // -------------------------------------------------------------------------
+
+    @Test
+    void create_nullTransactionAmount_defaultsToAmount() {
+        Expense noTx = VALID_NEW_EXPENSE.toBuilder().transactionAmount(null).build();
+        when(accountService.getById(eq(ACCOUNT_ID), eq(false))).thenReturn(VALID_ACCOUNT);
+        // MAPPEED_ENTITY carries transactionAmount == amount (1000.00): the defaulted entity.
+        when(repo.create(MAPPEED_ENTITY)).thenReturn(CREATED_ENTITY);
+
+        CreateExpenseResponse resp = service.create(new CreateExpenseRequest(noTx));
+
+        assertEquals(new BigDecimal("1000.00"), resp.value().transactionAmount());
+        verify(repo).create(MAPPEED_ENTITY);
+    }
+
+    @Test
+    void create_explicitTransactionAmount_isPreserved() {
+        Expense split = VALID_NEW_EXPENSE.toBuilder()
+            .amount(new BigDecimal("600.00"))
+            .transactionAmount(new BigDecimal("1000.00"))
+            .build();
+        ExpenseEntity expectedEntity = MAPPEED_ENTITY.toBuilder().amount(new BigDecimal("600.00")).build();
+        when(accountService.getById(eq(ACCOUNT_ID), eq(false))).thenReturn(VALID_ACCOUNT);
+        when(repo.create(expectedEntity)).thenReturn(expectedEntity.toBuilder().expenseId(EXPENSE_ID).build());
+
+        CreateExpenseResponse resp = service.create(new CreateExpenseRequest(split));
+
+        // Split line keeps its own amount but carries the original transaction total.
+        assertEquals(new BigDecimal("600.00"), resp.value().amount());
+        assertEquals(new BigDecimal("1000.00"), resp.value().transactionAmount());
+    }
+
+    @Test
+    void update_nullAmount_preservesStoredAmount() {
+        // Request omits amount; stored amount (1000.00) must be preserved, no validation error.
+        Expense req = UPDATED_EXPENSE.toBuilder().amount(null).build();
+        when(accountService.getById(anyLong(), anyBoolean())).thenReturn(VALID_ACCOUNT);
+        when(repo.get(anyLong())).thenReturn(Optional.of(CREATED_ENTITY));
+        when(repo.update(eq(EXPENSE_ID), any(ExpenseEntity.class)))
+            .thenAnswer(inv -> Optional.of(inv.getArgument(1)));
+
+        UpdateExpenseResponse resp = service.update(EXPENSE_ID, new UpdateExpenseRequest(req));
+
+        assertEquals(new BigDecimal("1000.00"), resp.value().amount());
+    }
+
+    @Test
+    void update_nullTransactionAmount_preservesStored_notRedefaultedToAmount() {
+        // Request changes amount to 100 but omits transactionAmount; stored tx (1000.00) is kept,
+        // NOT re-defaulted to the new amount.
+        Expense req = UPDATED_EXPENSE.toBuilder().transactionAmount(null).build();
+        when(accountService.getById(anyLong(), anyBoolean())).thenReturn(VALID_ACCOUNT);
+        when(repo.get(anyLong())).thenReturn(Optional.of(CREATED_ENTITY));
+        when(repo.update(eq(EXPENSE_ID), any(ExpenseEntity.class)))
+            .thenAnswer(inv -> Optional.of(inv.getArgument(1)));
+
+        UpdateExpenseResponse resp = service.update(EXPENSE_ID, new UpdateExpenseRequest(req));
+
+        assertEquals(new BigDecimal("100.00"), resp.value().amount());
+        assertEquals(new BigDecimal("1000.00"), resp.value().transactionAmount());
+    }
+
     @Test
     void update_accountNotOwned_throwsAccountNotFound() {
         when(accountService.getById(eq(VALID_NEW_EXPENSE.accountId()), eq(false)))
@@ -288,7 +356,7 @@ public class ExpenseServiceTest {
     }
 
     @ParameterizedTest(name = "create_testInvalidInputs-{0}")
-    @MethodSource("invalidExpenses")
+    @MethodSource("invalidCreateExpenses")
     void create_testInvalidInputs(String testName, Expense expense) {
         CreateExpenseRequest request = new CreateExpenseRequest(expense);
         assertThrows(ExpenseValidationException.class, () -> service.create(request));
@@ -301,6 +369,7 @@ public class ExpenseServiceTest {
         assertThrows(ExpenseValidationException.class, () -> service.update(EXPENSE_ID, updateExpenseRequest));
     }
 
+    /** Cases invalid for both create and update (amount is NOT included — it is partial on update). */
     static Stream<Arguments> invalidExpenses() {
         return Stream.of(
             Arguments.of(
@@ -309,6 +378,7 @@ public class ExpenseServiceTest {
                     null,
                     null,
                     ACCOUNT_ID,
+                    new BigDecimal("1000.00"),
                     new BigDecimal("1000.00"),
                     "Expensive Tacos",
                     SubCategory.RESTAURANT,
@@ -320,16 +390,7 @@ public class ExpenseServiceTest {
                     LocalDate.of(2026, 5, 25),
                     null,
                     new BigDecimal("1000.00"),
-                    "Expensive Tacos",
-                    SubCategory.RESTAURANT,
-                    "user-1")),
-            Arguments.of(
-                "invalid_account_amount",
-                new Expense(
-                    null,
-                    LocalDate.of(2026, 5, 25),
-                    ACCOUNT_ID,
-                    null,
+                    new BigDecimal("1000.00"),
                     "Expensive Tacos",
                     SubCategory.RESTAURANT,
                     "user-1")),
@@ -339,6 +400,7 @@ public class ExpenseServiceTest {
                     null,
                     LocalDate.of(2026, 5, 25),
                     ACCOUNT_ID,
+                    new BigDecimal("1000.00"),
                     new BigDecimal("1000.00"),
                     null,
                     SubCategory.RESTAURANT,
@@ -350,6 +412,7 @@ public class ExpenseServiceTest {
                     LocalDate.of(2026, 5, 25),
                     ACCOUNT_ID,
                     new BigDecimal("1000.00"),
+                    new BigDecimal("1000.00"),
                     "",
                     SubCategory.RESTAURANT,
                     "user-1")),
@@ -359,6 +422,7 @@ public class ExpenseServiceTest {
                     null,
                     LocalDate.of(2026, 5, 25),
                     ACCOUNT_ID,
+                    new BigDecimal("1000.00"),
                     new BigDecimal("1000.00"),
                     "Expensive Tacos",
                     null,
@@ -370,6 +434,7 @@ public class ExpenseServiceTest {
                     LocalDate.of(2026, 5, 25),
                     ACCOUNT_ID,
                     new BigDecimal("1000.00"),
+                    new BigDecimal("1000.00"),
                     "Expensive Tacos",
                     SubCategory.RESTAURANT,
                     null)),
@@ -380,9 +445,30 @@ public class ExpenseServiceTest {
                     LocalDate.of(2026, 5, 25),
                     ACCOUNT_ID,
                     new BigDecimal("1000.00"),
+                    new BigDecimal("1000.00"),
                     "Expensive Tacos",
                     SubCategory.RESTAURANT,
                     "")));
+    }
+
+    /**
+     * Cases invalid for create: everything in {@link #invalidExpenses()} plus a null amount.
+     * On create a null amount is rejected; on update it is allowed (preserves the stored value).
+     */
+    static Stream<Arguments> invalidCreateExpenses() {
+        return Stream.concat(
+            invalidExpenses(),
+            Stream.of(Arguments.of(
+                "invalid_account_amount",
+                new Expense(
+                    null,
+                    LocalDate.of(2026, 5, 25),
+                    ACCOUNT_ID,
+                    null,
+                    null,
+                    "Expensive Tacos",
+                    SubCategory.RESTAURANT,
+                    "user-1"))));
     }
 
     // -------------------------------------------------------------------------
@@ -393,10 +479,10 @@ public class ExpenseServiceTest {
     @Test
     void listByUser_bothDatesAbsent_defaultsToLastCalendarMonth() {
         when(repo.findByFiltersCursor(eq("user-1"), eq(LAST_MONTH_START), eq(LAST_MONTH_END),
-            isNull(), isNull(), isNull(), eq(20), isNull()))
+            isNull(), isNull(), isNull(), isNull(), eq(20), isNull()))
             .thenReturn(List.of());
 
-        CursorPageResponse<Expense> result = service.listByUser("user-1", null, null, null, null, null, null, null);
+        CursorPageResponse<Expense> result = service.listByUser("user-1", null, null, null, null, null, null, null, null);
 
         assertNotNull(result);
         assertNull(result.nextCursor());
@@ -408,10 +494,10 @@ public class ExpenseServiceTest {
         LocalDate expectedEnd = start.plusMonths(1);
 
         when(repo.findByFiltersCursor(eq("user-1"), eq(start), eq(expectedEnd),
-            isNull(), isNull(), isNull(), anyInt(), isNull()))
+            isNull(), isNull(), isNull(), isNull(), anyInt(), isNull()))
             .thenReturn(List.of());
 
-        service.listByUser("user-1", start, null, null, null, null, null, null);
+        service.listByUser("user-1", start, null, null, null, null, null, null, null);
     }
 
     @Test
@@ -420,10 +506,10 @@ public class ExpenseServiceTest {
         LocalDate expectedStart = end.minusMonths(1);
 
         when(repo.findByFiltersCursor(eq("user-1"), eq(expectedStart), eq(end),
-            isNull(), isNull(), isNull(), anyInt(), isNull()))
+            isNull(), isNull(), isNull(), isNull(), anyInt(), isNull()))
             .thenReturn(List.of());
 
-        service.listByUser("user-1", null, end, null, null, null, null, null);
+        service.listByUser("user-1", null, end, null, null, null, null, null, null);
     }
 
     // -------------------------------------------------------------------------
@@ -434,25 +520,25 @@ public class ExpenseServiceTest {
     @ValueSource(ints = {-5, -1, 0, 101, 200})
     void listByUser_invalidLimit_throws400(int limit) {
         assertThrows(ExpenseValidationException.class,
-            () -> service.listByUser("user-1", null, null, limit, null, null, null, null));
+            () -> service.listByUser("user-1", null, null, limit, null, null, null, null, null));
     }
 
     @Test
     void listByUser_limitAtMaximum_isAllowed() {
         when(repo.findByFiltersCursor(eq("user-1"), any(), any(),
-            isNull(), isNull(), isNull(), eq(100), isNull()))
+            isNull(), isNull(), isNull(), isNull(), eq(100), isNull()))
             .thenReturn(List.of());
 
-        service.listByUser("user-1", null, null, 100, null, null, null, null);
+        service.listByUser("user-1", null, null, 100, null, null, null, null, null);
     }
 
     @Test
     void listByUser_limitAbsent_defaultsTo20() {
         when(repo.findByFiltersCursor(eq("user-1"), any(), any(),
-            isNull(), isNull(), isNull(), eq(20), isNull()))
+            isNull(), isNull(), isNull(), isNull(), eq(20), isNull()))
             .thenReturn(List.of());
 
-        service.listByUser("user-1", null, null, null, null, null, null, null);
+        service.listByUser("user-1", null, null, null, null, null, null, null, null);
     }
 
     // -------------------------------------------------------------------------
@@ -466,7 +552,7 @@ public class ExpenseServiceTest {
         String cursor = ExpenseCursor.encode(LocalDate.of(2026, 3, 1), 10L);
 
         assertThrows(InvalidCursorException.class,
-            () -> service.listByUser("user-1", start, end, null, cursor, null, null, null));
+            () -> service.listByUser("user-1", start, end, null, cursor, null, null, null, null));
     }
 
     // -------------------------------------------------------------------------
@@ -476,7 +562,7 @@ public class ExpenseServiceTest {
     @Test
     void listByUser_categoryAndSubcategoryBothProvided_throws400() {
         assertThrows(ExpenseValidationException.class,
-            () -> service.listByUser("user-1", null, null, null, null, "Food", "Groceries", null));
+            () -> service.listByUser("user-1", null, null, null, null, "Food", "Groceries", null, null));
     }
 
     // -------------------------------------------------------------------------
@@ -486,37 +572,50 @@ public class ExpenseServiceTest {
     @Test
     void listByUser_categoryFilter_passedToRepo() {
         when(repo.findByFiltersCursor(eq("user-1"), any(), any(),
-            eq("Food"), isNull(), isNull(), anyInt(), isNull()))
+            eq("Food"), isNull(), isNull(), isNull(), anyInt(), isNull()))
             .thenReturn(List.of());
 
-        service.listByUser("user-1", null, null, null, null, "Food", null, null);
+        service.listByUser("user-1", null, null, null, null, "Food", null, null, null);
 
         verify(repo).findByFiltersCursor(eq("user-1"), any(), any(),
-            eq("Food"), isNull(), isNull(), anyInt(), isNull());
+            eq("Food"), isNull(), isNull(), isNull(), anyInt(), isNull());
     }
 
     @Test
     void listByUser_subcategoryFilter_passedToRepo() {
         when(repo.findByFiltersCursor(eq("user-1"), any(), any(),
-            isNull(), eq("Groceries"), isNull(), anyInt(), isNull()))
+            isNull(), eq("Groceries"), isNull(), isNull(), anyInt(), isNull()))
             .thenReturn(List.of());
 
-        service.listByUser("user-1", null, null, null, null, null, "Groceries", null);
+        service.listByUser("user-1", null, null, null, null, null, "Groceries", null, null);
 
         verify(repo).findByFiltersCursor(eq("user-1"), any(), any(),
-            isNull(), eq("Groceries"), isNull(), anyInt(), isNull());
+            isNull(), eq("Groceries"), isNull(), isNull(), anyInt(), isNull());
     }
 
     @Test
     void listByUser_accountIdFilter_passedToRepo() {
         when(repo.findByFiltersCursor(eq("user-1"), any(), any(),
-            isNull(), isNull(), eq(3L), anyInt(), isNull()))
+            isNull(), isNull(), eq(3L), isNull(), anyInt(), isNull()))
             .thenReturn(List.of());
 
-        service.listByUser("user-1", null, null, null, null, null, null, 3L);
+        service.listByUser("user-1", null, null, null, null, null, null, 3L, null);
 
         verify(repo).findByFiltersCursor(eq("user-1"), any(), any(),
-            isNull(), isNull(), eq(3L), anyInt(), isNull());
+            isNull(), isNull(), eq(3L), isNull(), anyInt(), isNull());
+    }
+
+    @Test
+    void listByUser_transactionAmountFilter_passedToRepo() {
+        BigDecimal txAmount = new BigDecimal("100.00");
+        when(repo.findByFiltersCursor(eq("user-1"), any(), any(),
+            isNull(), isNull(), isNull(), eq(txAmount), anyInt(), isNull()))
+            .thenReturn(List.of());
+
+        service.listByUser("user-1", null, null, null, null, null, null, null, txAmount);
+
+        verify(repo).findByFiltersCursor(eq("user-1"), any(), any(),
+            isNull(), isNull(), isNull(), eq(txAmount), anyInt(), isNull());
     }
 
     // -------------------------------------------------------------------------
@@ -533,10 +632,10 @@ public class ExpenseServiceTest {
             anEntity(9L,  LocalDate.of(2026, 4, 15)));
 
         when(repo.findByFiltersCursor(eq("user-1"), eq(start), eq(end),
-            isNull(), isNull(), isNull(), eq(2), isNull()))
+            isNull(), isNull(), isNull(), isNull(), eq(2), isNull()))
             .thenReturn(entities);
 
-        CursorPageResponse<Expense> result = service.listByUser("user-1", start, end, 2, null, null, null, null);
+        CursorPageResponse<Expense> result = service.listByUser("user-1", start, end, 2, null, null, null, null, null);
 
         assertNotNull(result.nextCursor());
     }
@@ -547,10 +646,10 @@ public class ExpenseServiceTest {
         LocalDate end = LocalDate.of(2026, 5, 1);
 
         when(repo.findByFiltersCursor(eq("user-1"), eq(start), eq(end),
-            isNull(), isNull(), isNull(), eq(20), isNull()))
+            isNull(), isNull(), isNull(), isNull(), eq(20), isNull()))
             .thenReturn(List.of(anEntity(5L, LocalDate.of(2026, 4, 10))));
 
-        CursorPageResponse<Expense> result = service.listByUser("user-1", start, end, null, null, null, null, null);
+        CursorPageResponse<Expense> result = service.listByUser("user-1", start, end, null, null, null, null, null, null);
 
         assertNull(result.nextCursor());
     }
@@ -607,7 +706,7 @@ public class ExpenseServiceTest {
     // -------------------------------------------------------------------------
 
     private ExpenseEntity anEntity(Long id, LocalDate date) {
-        return new ExpenseEntity(id, date, ACCOUNT_ID, new BigDecimal("50.00"), "Lunch",
+        return new ExpenseEntity(id, date, ACCOUNT_ID, new BigDecimal("50.00"), new BigDecimal("50.00"), "Lunch",
             CategoryMapper.getCategory(SubCategory.RESTAURANT).name(),
             SubCategory.RESTAURANT.name(), "user-1");
     }

--- a/src/test/java/com/novelosoftware/expenses/services/ExpenseServiceTest.java
+++ b/src/test/java/com/novelosoftware/expenses/services/ExpenseServiceTest.java
@@ -294,6 +294,31 @@ public class ExpenseServiceTest {
     }
 
     @Test
+    void create_transactionAmountTooManyDecimals_throws400() {
+        Expense bad = VALID_NEW_EXPENSE.toBuilder().transactionAmount(new BigDecimal("100.123")).build();
+        assertThrows(ExpenseValidationException.class,
+            () -> service.create(new CreateExpenseRequest(bad)));
+    }
+
+    @Test
+    void create_amountTooManyIntegerDigits_throws400() {
+        // 14 integer digits exceeds NUMERIC(15,2)'s 13-digit integer capacity.
+        Expense bad = VALID_NEW_EXPENSE.toBuilder()
+            .amount(new BigDecimal("12345678901234"))
+            .transactionAmount(new BigDecimal("12345678901234"))
+            .build();
+        assertThrows(ExpenseValidationException.class,
+            () -> service.create(new CreateExpenseRequest(bad)));
+    }
+
+    @Test
+    void update_transactionAmountTooManyDecimals_throws400() {
+        Expense bad = UPDATED_EXPENSE.toBuilder().transactionAmount(new BigDecimal("100.123")).build();
+        assertThrows(ExpenseValidationException.class,
+            () -> service.update(EXPENSE_ID, new UpdateExpenseRequest(bad)));
+    }
+
+    @Test
     void update_nullAmount_preservesStoredAmount() {
         // Request omits amount; stored amount (1000.00) must be preserved, no validation error.
         Expense req = UPDATED_EXPENSE.toBuilder().amount(null).build();


### PR DESCRIPTION
## What

Adds a `transactionAmount` field to expenses that records the amount of the original (pre-split) transaction a line was derived from, plus an exact-match search over it.

When one real-world transaction is split into multiple expense lines (e.g. a \$100 purchase → Groceries \$60 + Household \$40), each line can carry the original \$100 total so all lines from that transaction can later be found together.

## Changes

- **Schema**: additive nullable `transaction_amount NUMERIC(15,2)` column. **No index** in this change (deferred by request).
- **Field plumbing**: added to the `Expense` DTO, `ExpenseEntity`, mapper, and the repository INSERT/bulk/UPDATE/RowMapper.
- **Create / bulk-create**: when the caller omits `transactionAmount`, it defaults to the line's own `amount`. Never derived from splits.
- **Update is partial** for `amount` and `transactionAmount`: omitting either preserves the stored value. A null `amount` on update no longer returns 400, and a null `transactionAmount` is **not** re-defaulted to `amount`.
- **Search**: `GET /expenses?transaction_amount=` adds an exact-match filter that reuses the existing mandatory `created_by` + date-range criteria search and the existing cursor pagination. Combinable with `category`/`subcategory`/`account_id`; not encoded in the cursor (resupply per page).

## Notes for reviewers

- The filter is exposed only on `GET /expenses`; `listByAccount` passes `null` (signature unchanged), so account-scoped listing has no `transaction_amount` filter by design.
- The default-to-`amount` rule applies **only at creation**, never on update — update changes a field only when explicitly provided.
- Existing clients are unaffected: the field and filter are optional; pre-existing rows keep `transaction_amount = null` (no backfill).
- Planned via OpenSpec change `add-transaction-amount` (proposal/design/specs/tasks included under `openspec/changes/`).

## Testing

`./gradlew test integrationTest` — green (216 unit + 107 integration). New coverage: repository filter binding, service-layer create defaulting + partial-update preservation, controller param binding, and an end-to-end split-and-search integration test with cursor pagination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)