### PR TITLE
Rewrite README as portfolio piece; add API and architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,88 @@
-# expenses
-This repo contains an spring boot application that includes APIs for tracking expenses
+# Expenses
 
-## To run locally
-Make sure you have docker installed:
-- ./gradlew localRun
+> A spending tracker you *talk to* instead of tap through.
 
-## To stop postgres
-- docker-compose down -v
+Most expense apps die the same death: too much friction to log a purchase, too
+much friction to understand where the money went. So you drift back to a
+spreadsheet. Expenses is an experiment to remove that friction by putting a
+**chat interface** in front of a clean, well-specified API — so logging and
+understanding your spending feels like sending a message.
 
-## Curl examples
+---
 
-Create
+## Why another spending tracker?
+
+Yes, this is *another* one. Here's the honest reason: I keep abandoning expense
+apps. Every time I try to register a purchase, generate a report, or just
+understand my spending, there's enough friction that I give up and crawl back to
+my spreadsheet.
+
+The spreadsheet wins because it never gets in my way — but it can't read a
+receipt, split a charge, or answer a question. This project is my attempt to get
+the best of both: the zero-friction feel of a spreadsheet with the intelligence
+of an assistant.
+
+## What's different?
+
+The interface is a **chatbot**, not a sea of forms. The goal is to handle
+requests like:
+
+- *"Register this $14 spend as entertainment."*
+- *"Read this receipt and create a grocery expense."*
+- *"Give me a summary of my spending last month."*
+- *"How much have I spent on Amazon?"*
+- *"Split this $34.56 expense — $12.20 is Clothes, the rest stays Groceries."*
+
+Under the hood, an agent translates natural language into calls against a typed
+REST API with strong validation (e.g. a split's parts must sum back to the
+original amount). The chat is the easy part to *use*; the API is the part that
+keeps the data correct.
+
+## Tech at a glance
+
+Java 21 · Spring Boot 3.5 · PostgreSQL (plain JDBC, no ORM) · OAuth2 resource
+server · Testcontainers for integration tests. Development follows a
+**spec-driven workflow** with [OpenSpec](openspec/) — every behavioral change
+starts as a written proposal and spec before any code is touched.
+
+See **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** for the full design,
+module layout, and the reasoning behind these choices.
+
+## Running locally
+
+You'll need Docker installed.
+
 ```bash
-curl -i -X POST http://localhost:8080/accounts \
-  -H "Content-Type: application/json" \
-  -d '{
-    "value": { 
-        "name": "Bank of America",
-        "accountType": "CREDIT",
-        "currency": "USD",
-        "initialAmount": 1000.00,
-        "createdBy": "user-1"
-    }
-  }'
+# starts Postgres (docker compose) and boots the app with the local profile
+./gradlew localRun
 ```
 
-Update
+Stop the database when you're done:
+
 ```bash
-curl -i -X PUT http://localhost:8080/accounts/4 \
-  -H "Content-Type: application/json" \
-  -d '{ 
-        "value": {
-            "name": "Checking Updated",
-            "accountType": "CREDIT",
-            "currency": "USD",
-            "initialAmount": 1000.00,
-            "currentAmount": 1500.00,
-            "createdBy": "user-1"
-        }
-    }'
+docker compose down -v
 ```
 
-Find All
-```bash
-curl -i -X GET http://localhost:8080/accounts
-```
+## API
 
+The HTTP API covers accounts and expenses (create, update, list, delete,
+cursor pagination, criteria search, and amount splitting). Endpoints are
+secured with OAuth2 bearer tokens.
+
+Full request/response examples live in **[docs/API.md](docs/API.md)**.
+
+## Roadmap
+
+- **Agent skills** — fully exercise the API through Claude Code and Codex via
+  SKILLS, so any agent can drive it end to end.
+- **MCP server** — give agents a first-class way to understand the app and use
+  the API safely (validating, for example, that a split sums to the original
+  amount).
+- **Budgets & periods** — set a budget per category over a defined period, and
+  generate a report automatically when the period closes.
+- **Messaging integrations** — talk to it from WhatsApp or Telegram.
+
+---
+
+*This is a personal project and a work in progress — built in the open as part
+of my portfolio.*

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,171 @@
+# API reference
+
+Base URL (local): `http://localhost:8080`
+
+All endpoints are protected by an OAuth2 resource server. Requests must include a
+JWT bearer token issued by your configured OAuth2 / OIDC provider:
+
+```
+Authorization: Bearer <access-token>
+```
+
+How you obtain the token depends on your provider and grant of choice — the
+service only validates the token, it never issues one. See
+[ARCHITECTURE.md → Authentication](ARCHITECTURE.md#authentication) for what the
+provider must support and how to point the server at it. The examples below use a
+`$TOKEN` shell variable:
+
+```bash
+export TOKEN="<access-token>"
+```
+
+Request bodies wrap the payload in a `value` object.
+
+---
+
+## Accounts
+
+### Create an account
+
+```bash
+curl -i -X POST http://localhost:8080/accounts \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "value": {
+        "name": "Bank of America",
+        "accountType": "CREDIT",
+        "currency": "USD",
+        "initialAmount": 1000.00
+    }
+  }'
+```
+
+### Update an account
+
+```bash
+curl -i -X PUT http://localhost:8080/accounts/4 \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "value": {
+            "name": "Checking Updated",
+            "accountType": "CREDIT",
+            "currency": "USD",
+            "initialAmount": 1000.00,
+            "currentAmount": 1500.00
+        }
+    }'
+```
+
+### Get an account by id
+
+```bash
+curl -i http://localhost:8080/accounts/4 \
+  -H "Authorization: Bearer $TOKEN"
+# add ?includeGap=true to return the unexplained balance delta
+```
+
+### List the caller's accounts
+
+```bash
+curl -i http://localhost:8080/accounts/user \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Delete an account
+
+```bash
+curl -i -X DELETE http://localhost:8080/accounts/4 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### List expenses for an account
+
+```bash
+curl -i http://localhost:8080/accounts/4/expenses \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+---
+
+## Expenses
+
+### Create an expense
+
+```bash
+curl -i -X POST http://localhost:8080/expenses \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "value": {
+        "expenseDate": "2026-06-17",
+        "accountId": 4,
+        "amount": 34.56,
+        "description": "Weekly groceries",
+        "subCategory": "GROCERIES"
+    }
+  }'
+```
+
+`transactionAmount` records the original pre-split amount; when an expense is
+split into multiple lines, the line `amount`s should sum back to the original
+`transactionAmount`.
+
+### Bulk create expenses
+
+```bash
+curl -i -X POST http://localhost:8080/expenses/bulk \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "value": [
+        { "expenseDate": "2026-06-17", "accountId": 4, "amount": 12.20, "description": "Shirt", "subCategory": "CLOTHING", "transactionAmount": 34.56 },
+        { "expenseDate": "2026-06-17", "accountId": 4, "amount": 22.36, "description": "Groceries", "subCategory": "GROCERIES", "transactionAmount": 34.56 }
+    ]
+  }'
+```
+
+### Get an expense by id
+
+```bash
+curl -i http://localhost:8080/expenses/10 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### List / search expenses
+
+```bash
+# cursor-paginated list for the caller, with optional criteria filters
+curl -i "http://localhost:8080/expenses?limit=20" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Supported query parameters include cursor pagination and criteria search (date
+window, amount, transaction amount, etc.). See the OpenSpec specs under
+[`openspec/specs/expense-search-filters`](../openspec/specs/expense-search-filters)
+for the authoritative list.
+
+### Update an expense
+
+```bash
+curl -i -X PUT http://localhost:8080/expenses/10 \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "value": {
+        "expenseDate": "2026-06-17",
+        "accountId": 4,
+        "amount": 30.00,
+        "description": "Groceries (corrected)",
+        "subCategory": "GROCERIES"
+    }
+  }'
+```
+
+### Delete an expense
+
+```bash
+curl -i -X DELETE http://localhost:8080/expenses/10 \
+  -H "Authorization: Bearer $TOKEN"
+```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,123 @@
+# Architecture
+
+A short tour of how Expenses is built and why.
+
+## Stack
+
+| Concern            | Choice                                              |
+| ------------------ | --------------------------------------------------- |
+| Language / runtime | Java 21                                             |
+| Framework          | Spring Boot 3.5 (`spring-boot-starter-web`)         |
+| Persistence        | PostgreSQL via Spring JDBC (`JdbcTemplate`) — no ORM |
+| Auth               | OAuth2 resource server (JWT bearer tokens)          |
+| Build              | Gradle                                              |
+| Testing            | JUnit 5, Spring Security Test, Testcontainers, MockWebServer |
+
+## Why these choices
+
+- **Plain JDBC, no JPA/Hibernate.** SQL is hand-written and lives close to the
+  repositories. This keeps query behavior explicit and predictable — important
+  for things like cursor pagination and the gap calculation, where I want to
+  control exactly what hits the database. There is no entity graph or lazy
+  loading to reason about.
+- **OAuth2 resource server.** The API trusts signed JWTs and derives the caller
+  identity from the token rather than from request fields. Ownership is enforced
+  server-side so a user can only see and mutate their own accounts and expenses.
+  The service only *validates* tokens — it is provider-agnostic and issues
+  nothing itself (see [Authentication](#authentication)).
+- **DTO `value`-wrapping.** Request and response bodies wrap their payload in a
+  `value` field (e.g. `CreateAccountRequest(value)`), giving a stable envelope to
+  evolve around.
+
+## Module layout
+
+Source lives under `src/main/java/com/novelosoftware/expenses`:
+
+```
+controllers/   REST endpoints (AccountController, ExpenseController)
+services/      Business rules and orchestration
+repositories/  JdbcTemplate-backed data access
+entities/      Database row representations
+dto/           API request/response records + enums (Category, SubCategory, AccountType)
+mappers/       Entity <-> DTO translation
+security/      SecurityConfig, CurrentUser (caller identity from the JWT)
+exceptions/    Domain exceptions + GlobalExceptionHandler
+util/          Cursor encoding, date-window resolution
+```
+
+Database schema is defined in
+[`src/main/resources/db/schema.sql`](../src/main/resources/db/schema.sql).
+
+## Key domain concepts
+
+- **Accounts** have a type (debit/credit), currency, an `initialAmount`, a
+  `currentAmount`, and a `periodStart`.
+- **Gap** is the unexplained balance delta for an account:
+  `currentAmount - initialAmount - SUM(expenses since periodStart)`. It's only
+  computed on request (`?includeGap=true`) and surfaces money the recorded
+  expenses don't account for.
+- **Expenses** carry an `amount` plus a `transactionAmount` — the original
+  pre-split amount. Splitting one charge into several categorized lines is a
+  first-class idea, and a valid split's line amounts sum back to the original
+  transaction amount.
+- **Categories / sub-categories.** Expenses are tagged by `SubCategory`, from
+  which the broader `Category` is inferred.
+
+## Authentication
+
+The app is an OAuth2 **resource server** and nothing more — it validates incoming
+JWT access tokens but never issues, stores, or refreshes them. That keeps it
+independent of any single identity provider: point it at whichever OAuth2 / OIDC
+provider you run, and obtain tokens however that provider prefers (device flow,
+authorization code, client credentials, etc.).
+
+**What the provider must offer**
+
+- Issues **JWT access tokens** (signed; the server reads the `at+jwt` or `jwt`
+  token type).
+- Exposes an **OIDC / OAuth2 discovery document** at its issuer URL
+  (`<issuer>/.well-known/openid-configuration`), from which the server fetches the
+  signing keys (JWKS).
+- Sets a stable **`iss` (issuer)** claim and a **`sub`** claim — `sub` is treated
+  as the caller's user id and is what account/expense ownership is scoped to.
+
+**How the server is configured**
+
+Authentication activates by setting a single property to your provider's issuer
+URL:
+
+```properties
+spring.security.oauth2.resourceserver.jwt.issuer-uri=https://your-issuer.example.com/
+```
+
+The server then validates the signature against the provider's published keys and
+checks the standard claims (issuer, expiry). No client secrets or provider
+credentials live in this codebase. If the property is left empty, the
+issuer-based decoder is not wired up — useful for local/test profiles that
+supply their own decoder.
+
+## Configuration & profiles
+
+- `application.properties` — shared defaults
+- `application-local.properties` — local DB and RSA key for the `local` profile
+- `application-production.properties` — production settings
+
+`./gradlew localRun` starts Postgres via `docker compose up -d --wait`, then
+boots the app with the `local` profile.
+
+## Testing strategy
+
+- **Unit / slice tests** (`test`) run on every build.
+- **Integration tests** (`integrationTest`) spin up a real PostgreSQL container
+  with Testcontainers, and use MockWebServer to stand in for the OAuth provider —
+  so auth and persistence are exercised against real-ish dependencies rather than
+  mocks.
+
+## Spec-driven development
+
+Behavioral changes are designed before they're coded, using
+[OpenSpec](https://github.com/Fission-AI/OpenSpec). Each change starts as a
+`proposal.md` + `design.md` + delta `spec.md` under `openspec/changes/`, gets
+implemented against its tasks, then is synced into the canonical specs under
+`openspec/specs/` and archived. The `openspec/specs/` directory is the
+authoritative description of current API behavior.


### PR DESCRIPTION
## Summary
Reworks the project's documentation for a portfolio audience.

- **README.md** rewritten around the product story: why another spending tracker, the chatbot-first interface (with example prompts), a brief tech-at-a-glance, and a roadmap. Setup stays lean.
- **docs/API.md** holds the curl examples, moved out of the README and refreshed — every call now uses OAuth bearer auth (stale `createdBy`/no-auth examples removed), covering the current account/expense endpoints, bulk create, cursor list/search, and `?includeGap=true`.
- **docs/ARCHITECTURE.md** (new) documents the stack and design decisions (plain JDBC over JPA, gap calculation, expense splitting), module layout, testing strategy, and the OpenSpec spec-driven workflow.

## Notes
- Authentication is documented as **provider-agnostic**: the service only validates JWTs via an `issuer-uri`, so no specific identity provider is named. Architecture doc lists what any OAuth2/OIDC provider must offer.
- Example enum values verified against the source (`SubCategory.CLOTHING`, `AccountType`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)