### PR TITLE
Add SECURITY.md documenting secret handling

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security
+
+## Reporting a vulnerability
+
+This is a personal project. If you find a security issue, please open an issue or
+contact the maintainer directly rather than disclosing it publicly.
+
+## How secrets are handled
+
+No production secrets live in this repository. Sensitive configuration is supplied
+at runtime through environment variables, not committed files:
+
+- **OAuth issuer** — `spring.security.oauth2.resourceserver.jwt.issuer-uri` reads
+  from the `OAUTH_ISSUER_URI` environment variable (empty by default). The service
+  is a resource server only: it validates JWTs against the provider's published
+  keys and never issues, stores, or signs production tokens.
+- **Database credentials (production)** — supplied via Spring's standard
+  `SPRING_DATASOURCE_*` environment variables. The production profile contains no
+  inline URL, username, or password.
+
+## About the committed values
+
+Some non-secret, local-only values are intentionally committed so the project runs
+out of the box:
+
+- **`src/test/resources/local/test-rsa-*.pem`** — a throwaway RSA key pair used
+  **only** in local and integration tests to mint and validate JWTs against an
+  in-memory/test setup. It is **not** a production signing key and has no bearing
+  on deployed environments, which validate tokens via the configured OAuth
+  provider's JWKS. It is safe to commit, but is called out here so automated
+  secret scanners and reviewers understand its scope.
+- **Local Postgres credentials** (`postgres`/`postgres` in
+  `application-local.properties` and `docker-compose.yaml`) — disposable
+  credentials for a local development container. They are not used in any
+  deployed environment.


### PR DESCRIPTION
## Summary
Adds a `SECURITY.md` clarifying how secrets are handled, prompted by a pre-publication review of the public repo.

- Documents that production secrets are env-driven: OAuth issuer via `OAUTH_ISSUER_URI`, DB credentials via `SPRING_DATASOURCE_*`. No production secrets are committed.
- Explains the scope of the intentionally-committed local values so reviewers and automated secret scanners understand them:
  - `src/test/resources/local/test-rsa-*.pem` — test-only key pair, not a production signing key.
  - Local `postgres`/`postgres` credentials — disposable local-dev container values.

No code or configuration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)